### PR TITLE
fix: [SD-9349] screen reader for edge android

### DIFF
--- a/.github/workflows/prettier.yml
+++ b/.github/workflows/prettier.yml
@@ -8,4 +8,4 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Run Prettier
-        run: npm install -g prettier && npx prettier --check .
+        run: npm install -g prettier@^3.0.3 && npx prettier --check .

--- a/.github/workflows/prettier.yml
+++ b/.github/workflows/prettier.yml
@@ -8,4 +8,4 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Run Prettier
-        run: npm install -g prettier@^3.0.3 && npx prettier --check .
+        run: npx prettier@^3.0.3 --check .

--- a/.github/workflows/prettier.yml
+++ b/.github/workflows/prettier.yml
@@ -8,4 +8,4 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Run Prettier
-        run: npx prettier@^3.0.3 --check .
+        run: npm install -g prettier@~3.0.3 && npx prettier --check .

--- a/projects/astral-accessibility/src/lib/controls/screen-reader.component.ts
+++ b/projects/astral-accessibility/src/lib/controls/screen-reader.component.ts
@@ -115,7 +115,11 @@ export class ScreenReaderComponent {
     }
   }
 
-  getDefaultVoice(voices: Array<SpeechSynthesisVoice>, isApple = false, isEdgeAndroid = false) {
+  getDefaultVoice(
+    voices: Array<SpeechSynthesisVoice>,
+    isApple = false,
+    isEdgeAndroid = false,
+  ) {
     const defaultVoice = "Daniel";
 
     // Note: Edge Android doesn't have any voices, but still works without setting the voice
@@ -169,7 +173,11 @@ export class ScreenReaderComponent {
     voices = speechSynthesis.getVoices();
 
     // default settings, currently user has no way of modifying these
-    this.speech.voice = this.getDefaultVoice(voices, this.isApple, this.isEdgeAndroid);
+    this.speech.voice = this.getDefaultVoice(
+      voices,
+      this.isApple,
+      this.isEdgeAndroid,
+    );
     this.speech.lang = "en";
     this.speech.rate = 1;
     this.speech.pitch = 1;
@@ -180,7 +188,11 @@ export class ScreenReaderComponent {
     if (!voices.length) {
       speechSynthesis.addEventListener("voiceschanged", () => {
         voices = speechSynthesis.getVoices();
-        this.speech.voice = this.getDefaultVoice(voices, this.isApple, this.isEdgeAndroid);
+        this.speech.voice = this.getDefaultVoice(
+          voices,
+          this.isApple,
+          this.isEdgeAndroid,
+        );
       });
     }
 


### PR DESCRIPTION
### Bug
Screen reader broken on Edge Android.

https://vertoinc.atlassian.net/browse/SD-9349

### Cause
No voices were available when calling `speechSynthesis.getVoices()`, it's a bug within Edge Android itself.

https://answers.microsoft.com/en-us/microsoftedge/forum/all/text-to-speech-speech-synthesis-broken-on-mobile/f160ee1a-dd68-436e-b44b-64d1203411e7

### Fix
Don't set the voice, it still works when it's null.