### PR TITLE
feat: add language setting to widget via i18n translation service

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,7 @@
+{
+  "semi": true,
+  "singleQuote": false,
+  "trailingComma": "all",
+  "printWidth": 80,
+  "tabWidth": 2
+}

--- a/README.md
+++ b/README.md
@@ -97,6 +97,53 @@ Optionally we can choose which widgets should appear by passing an object inside
 </script>
 ```
 
+## Language Support
+
+Astral supports multiple languages for the widget UI labels and text-to-speech voice selection. The built-in languages are:
+
+| Code      | Language            |
+| --------- | ------------------- |
+| `en`      | English (default)   |
+| `fr`      | French              |
+| `zh-Hant` | Traditional Chinese |
+
+### Setting the language at initialisation
+
+Pass a `language` key to `initializeAstral`:
+
+```html
+<script>
+  initializeAstral({
+    enabledFeatures: ["Screen Reader", "Contrast"],
+    language: "fr",
+  });
+</script>
+```
+
+### Switching language at runtime
+
+After initialisation, call `window.astralSetLanguage` with a language code. This updates both the widget labels and the screen reader's text-to-speech voice:
+
+```js
+window.astralSetLanguage("zh-Hant");
+```
+
+A typical pattern when your page has its own language switcher:
+
+```html
+<select id="lang-select">
+  <option value="en">English</option>
+  <option value="fr">Français</option>
+  <option value="zh-Hant">繁體中文</option>
+</select>
+
+<script>
+  document.getElementById("lang-select").addEventListener("change", (e) => {
+    window.astralSetLanguage(e.target.value);
+  });
+</script>
+```
+
 ## Development Setup
 
 1. Clone the repository

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "build:lib:dev": "ng build astral-accessibility --watch --configuration=development --single-bundle",
     "start:demo-server": "lite-server -c projects/demo/lite-server-config.json",
     "start:demo": "lite-server -c projects/demo/lite-server-config.json",
-    "start:test-server": "npm-run-all build:lib start:demo-server"
+    "start:test-server": "npm-run-all build:lib start:demo-server",
+    "format": "prettier --write \"projects/**/*.{ts,html,scss,json}\" \"*.json\""
   },
   "private": true,
   "dependencies": {

--- a/projects/astral-accessibility/src/lib/astral-accessibility.component.spec.ts
+++ b/projects/astral-accessibility/src/lib/astral-accessibility.component.spec.ts
@@ -1,6 +1,7 @@
 import { ComponentFixture, TestBed } from "@angular/core/testing";
 
 import { AstralAccessibilityComponent } from "./astral-accessibility.component";
+import { AstralTranslationService } from "./astral-translation.service";
 
 describe("AstralAccessibilityComponent", () => {
   let component: AstralAccessibilityComponent;
@@ -8,7 +9,8 @@ describe("AstralAccessibilityComponent", () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      declarations: [AstralAccessibilityComponent],
+      imports: [AstralAccessibilityComponent],
+      providers: [AstralTranslationService],
     }).compileComponents();
 
     fixture = TestBed.createComponent(AstralAccessibilityComponent);

--- a/projects/astral-accessibility/src/lib/astral-accessibility.component.ts
+++ b/projects/astral-accessibility/src/lib/astral-accessibility.component.ts
@@ -8,6 +8,7 @@ import { TextSpacingComponent } from "./controls/text-spacing.component";
 import { ScreenReaderComponent } from "./controls/screen-reader.component";
 import { ScreenMaskComponent } from "./controls/screen-mask.component";
 import { LineHeightComponent } from "./controls/line-height.component";
+import { AstralTranslationService } from "./astral-translation.service";
 
 @Component({
   selector: "astral-accessibility",
@@ -35,6 +36,8 @@ export class AstralAccessibilityComponent {
   options: Record<string, any> = {};
   enabledFeatures: String[] = [];
 
+  constructor(private translationService: AstralTranslationService) {}
+
   ngOnInit() {
     const astralElement = document.querySelector("astral-accessibility");
     const astralOptions = astralElement?.getAttribute("astral-features");
@@ -42,6 +45,9 @@ export class AstralAccessibilityComponent {
     if (astralOptions) {
       this.options = JSON.parse(astralOptions);
       this.enabledFeatures = this.options["enabledFeatures"];
+      if (this.options["language"]) {
+        this.translationService.setLanguage(this.options["language"]);
+      }
     }
 
     const phones =

--- a/projects/astral-accessibility/src/lib/astral-translation.service.spec.ts
+++ b/projects/astral-accessibility/src/lib/astral-translation.service.spec.ts
@@ -1,0 +1,47 @@
+import { AstralTranslationService } from "./astral-translation.service";
+
+describe("AstralTranslationService", () => {
+  let service: AstralTranslationService;
+
+  beforeEach(() => {
+    service = new AstralTranslationService();
+  });
+
+  it("returns English strings by default", () => {
+    expect(service.t("contrast.base")).toBe("Contrast");
+    expect(service.t("screenReader.base")).toBe("Screen Reader");
+    expect(service.t("lineHeight.heavy")).toBe("Heavy Height");
+  });
+
+  it("returns French strings after setLanguage('fr')", () => {
+    service.setLanguage("fr");
+    expect(service.t("contrast.base")).toBe("Contraste");
+    expect(service.t("screenReader.base")).toBe("Lecteur d'écran");
+    expect(service.t("lineHeight.heavy")).toBe("Hauteur importante");
+  });
+
+  it("returns Traditional Chinese strings after setLanguage('zh-Hant')", () => {
+    service.setLanguage("zh-Hant");
+    expect(service.t("contrast.base")).toBe("對比度");
+    expect(service.t("screenReader.base")).toBe("螢幕閱讀器");
+    expect(service.t("lineHeight.heavy")).toBe("重度行高");
+  });
+
+  it("falls back to English for an unknown language code", () => {
+    service.setLanguage("de");
+    expect(service.t("contrast.base")).toBe("Contrast");
+  });
+
+  it("returns the key itself when a translation key is missing", () => {
+    expect(service.t("nonexistent.key")).toBe("nonexistent.key");
+  });
+
+  it("can switch language more than once", () => {
+    service.setLanguage("fr");
+    expect(service.t("contrast.base")).toBe("Contraste");
+    service.setLanguage("zh-Hant");
+    expect(service.t("contrast.base")).toBe("對比度");
+    service.setLanguage("en");
+    expect(service.t("contrast.base")).toBe("Contrast");
+  });
+});

--- a/projects/astral-accessibility/src/lib/astral-translation.service.ts
+++ b/projects/astral-accessibility/src/lib/astral-translation.service.ts
@@ -1,0 +1,36 @@
+import { Injectable } from "@angular/core";
+import { Subject } from "rxjs";
+import EN from "./i18n/en.json";
+import FR from "./i18n/fr.json";
+import ZH_HANT from "./i18n/zh-Hant.json";
+
+@Injectable({ providedIn: "root" })
+export class AstralTranslationService {
+  private translations: Record<string, string> = EN as Record<string, string>;
+  private lang: string = "en";
+
+  readonly langChange = new Subject<string>();
+
+  get currentLang(): string {
+    return this.lang;
+  }
+
+  setLanguage(lang: string): void {
+    this.lang = lang;
+    switch (lang) {
+      case "fr":
+        this.translations = FR as Record<string, string>;
+        break;
+      case "zh-Hant":
+        this.translations = ZH_HANT as Record<string, string>;
+        break;
+      default:
+        this.translations = EN as Record<string, string>;
+    }
+    this.langChange.next(this.lang);
+  }
+
+  t(key: string): string {
+    return this.translations[key] ?? key;
+  }
+}

--- a/projects/astral-accessibility/src/lib/controls/contrast.component.spec.ts
+++ b/projects/astral-accessibility/src/lib/controls/contrast.component.spec.ts
@@ -1,0 +1,41 @@
+import { TestBed } from "@angular/core/testing";
+import { ContrastComponent } from "./contrast.component";
+import { AstralTranslationService } from "../astral-translation.service";
+
+describe("ContrastComponent labels", () => {
+  let component: ContrastComponent;
+  let translationService: AstralTranslationService;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [ContrastComponent],
+    }).compileComponents();
+
+    translationService = TestBed.inject(AstralTranslationService);
+    const fixture = TestBed.createComponent(ContrastComponent);
+    component = fixture.componentInstance;
+  });
+
+  it("returns English labels by default", () => {
+    expect(component.labels[0]).toBe("Contrast");
+    expect(component.labels[1]).toBe("Invert");
+    expect(component.labels[2]).toBe("High Contrast");
+    expect(component.labels[3]).toBe("Dark High Contrast");
+  });
+
+  it("returns French labels after setLanguage('fr')", () => {
+    translationService.setLanguage("fr");
+    expect(component.labels[0]).toBe("Contraste");
+    expect(component.labels[1]).toBe("Inverser");
+    expect(component.labels[2]).toBe("Contraste élevé");
+    expect(component.labels[3]).toBe("Contraste élevé sombre");
+  });
+
+  it("returns Traditional Chinese labels after setLanguage('zh-Hant')", () => {
+    translationService.setLanguage("zh-Hant");
+    expect(component.labels[0]).toBe("對比度");
+    expect(component.labels[1]).toBe("反轉");
+    expect(component.labels[2]).toBe("高對比度");
+    expect(component.labels[3]).toBe("深色高對比度");
+  });
+});

--- a/projects/astral-accessibility/src/lib/controls/contrast.component.ts
+++ b/projects/astral-accessibility/src/lib/controls/contrast.component.ts
@@ -1,6 +1,7 @@
 import { DOCUMENT, NgIf, NgClass } from "@angular/common";
 import { Component, inject } from "@angular/core";
 import { AstralCheckmarkSvgComponent } from "../util/astral-checksvg.component";
+import { AstralTranslationService } from "../astral-translation.service";
 
 @Component({
   selector: "astral-contrast",
@@ -51,7 +52,7 @@ import { AstralCheckmarkSvgComponent } from "../util/astral-checksvg.component";
           </div>
 
           <div class="state-dots-wrap">
-            <span>{{ states[currentState] }}</span>
+            <span>{{ labels[currentState] }}</span>
             <div
               class="dots"
               [ngClass]="{ inactive: states[currentState] === base }"
@@ -85,9 +86,20 @@ import { AstralCheckmarkSvgComponent } from "../util/astral-checksvg.component";
 export class ContrastComponent {
   document = inject(DOCUMENT);
 
+  constructor(private translation: AstralTranslationService) {}
+
   currentState = 0;
   base = "Contrast";
   states = [this.base, "Invert", "High Contrast", "Dark High Contrast"];
+
+  get labels(): string[] {
+    return [
+      this.translation.t("contrast.base"),
+      this.translation.t("contrast.invert"),
+      this.translation.t("contrast.high"),
+      this.translation.t("contrast.darkHigh"),
+    ];
+  }
 
   _style: HTMLStyleElement;
 

--- a/projects/astral-accessibility/src/lib/controls/line-height.component.spec.ts
+++ b/projects/astral-accessibility/src/lib/controls/line-height.component.spec.ts
@@ -1,0 +1,41 @@
+import { TestBed } from "@angular/core/testing";
+import { LineHeightComponent } from "./line-height.component";
+import { AstralTranslationService } from "../astral-translation.service";
+
+describe("LineHeightComponent labels", () => {
+  let component: LineHeightComponent;
+  let translationService: AstralTranslationService;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [LineHeightComponent],
+    }).compileComponents();
+
+    translationService = TestBed.inject(AstralTranslationService);
+    const fixture = TestBed.createComponent(LineHeightComponent);
+    component = fixture.componentInstance;
+  });
+
+  it("returns English labels by default", () => {
+    expect(component.labels[0]).toBe("Line Height");
+    expect(component.labels[1]).toBe("Light Height");
+    expect(component.labels[2]).toBe("Moderate Height");
+    expect(component.labels[3]).toBe("Heavy Height");
+  });
+
+  it("returns French labels after setLanguage('fr')", () => {
+    translationService.setLanguage("fr");
+    expect(component.labels[0]).toBe("Hauteur de ligne");
+    expect(component.labels[1]).toBe("Hauteur légère");
+    expect(component.labels[2]).toBe("Hauteur modérée");
+    expect(component.labels[3]).toBe("Hauteur importante");
+  });
+
+  it("returns Traditional Chinese labels after setLanguage('zh-Hant')", () => {
+    translationService.setLanguage("zh-Hant");
+    expect(component.labels[0]).toBe("行高");
+    expect(component.labels[1]).toBe("輕度行高");
+    expect(component.labels[2]).toBe("中度行高");
+    expect(component.labels[3]).toBe("重度行高");
+  });
+});

--- a/projects/astral-accessibility/src/lib/controls/line-height.component.ts
+++ b/projects/astral-accessibility/src/lib/controls/line-height.component.ts
@@ -1,6 +1,7 @@
 import { DOCUMENT, NgIf, NgClass } from "@angular/common";
 import { Component, Renderer2, inject } from "@angular/core";
 import { AstralCheckmarkSvgComponent } from "../util/astral-checksvg.component";
+import { AstralTranslationService } from "../astral-translation.service";
 
 @Component({
   selector: "astral-line-height",
@@ -37,7 +38,7 @@ import { AstralCheckmarkSvgComponent } from "../util/astral-checksvg.component";
           </div>
 
           <div class="state-dots-wrap">
-            <span>{{ states[currentState] }}</span>
+            <span>{{ labels[currentState] }}</span>
             <div
               class="dots"
               [ngClass]="{ inactive: states[currentState] === base }"
@@ -69,7 +70,20 @@ import { AstralCheckmarkSvgComponent } from "../util/astral-checksvg.component";
   imports: [NgIf, NgClass, AstralCheckmarkSvgComponent],
 })
 export class LineHeightComponent {
-  constructor(private renderer: Renderer2) {}
+  constructor(
+    private renderer: Renderer2,
+    private translation: AstralTranslationService,
+  ) {}
+
+  get labels(): string[] {
+    return [
+      this.translation.t("lineHeight.base"),
+      this.translation.t("lineHeight.light"),
+      this.translation.t("lineHeight.moderate"),
+      this.translation.t("lineHeight.heavy"),
+    ];
+  }
+
   document = inject(DOCUMENT);
 
   currentState = 0;

--- a/projects/astral-accessibility/src/lib/controls/saturate.component.spec.ts
+++ b/projects/astral-accessibility/src/lib/controls/saturate.component.spec.ts
@@ -1,0 +1,41 @@
+import { TestBed } from "@angular/core/testing";
+import { SaturateComponent } from "./saturate.component";
+import { AstralTranslationService } from "../astral-translation.service";
+
+describe("SaturateComponent labels", () => {
+  let component: SaturateComponent;
+  let translationService: AstralTranslationService;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [SaturateComponent],
+    }).compileComponents();
+
+    translationService = TestBed.inject(AstralTranslationService);
+    const fixture = TestBed.createComponent(SaturateComponent);
+    component = fixture.componentInstance;
+  });
+
+  it("returns English labels by default", () => {
+    expect(component.labels[0]).toBe("Saturation");
+    expect(component.labels[1]).toBe("Low Saturation");
+    expect(component.labels[2]).toBe("High Saturation");
+    expect(component.labels[3]).toBe("Desaturated");
+  });
+
+  it("returns French labels after setLanguage('fr')", () => {
+    translationService.setLanguage("fr");
+    expect(component.labels[0]).toBe("Saturation");
+    expect(component.labels[1]).toBe("Faible saturation");
+    expect(component.labels[2]).toBe("Haute saturation");
+    expect(component.labels[3]).toBe("Désaturé");
+  });
+
+  it("returns Traditional Chinese labels after setLanguage('zh-Hant')", () => {
+    translationService.setLanguage("zh-Hant");
+    expect(component.labels[0]).toBe("飽和度");
+    expect(component.labels[1]).toBe("低飽和度");
+    expect(component.labels[2]).toBe("高飽和度");
+    expect(component.labels[3]).toBe("去飽和");
+  });
+});

--- a/projects/astral-accessibility/src/lib/controls/saturate.component.ts
+++ b/projects/astral-accessibility/src/lib/controls/saturate.component.ts
@@ -1,6 +1,7 @@
 import { DOCUMENT, NgIf, NgClass } from "@angular/common";
 import { Component, inject } from "@angular/core";
 import { AstralCheckmarkSvgComponent } from "../util/astral-checksvg.component";
+import { AstralTranslationService } from "../astral-translation.service";
 
 @Component({
   selector: "astral-saturate",
@@ -56,7 +57,7 @@ import { AstralCheckmarkSvgComponent } from "../util/astral-checksvg.component";
             </svg>
           </div>
           <div class="state-dots-wrap">
-            <span>{{ states[currentState] }}</span>
+            <span>{{ labels[currentState] }}</span>
             <div *ngIf="states[currentState] != base" class="dots">
               <div
                 class="dot"
@@ -87,6 +88,17 @@ import { AstralCheckmarkSvgComponent } from "../util/astral-checksvg.component";
   imports: [NgIf, NgClass, AstralCheckmarkSvgComponent],
 })
 export class SaturateComponent {
+  constructor(private translation: AstralTranslationService) {}
+
+  get labels(): string[] {
+    return [
+      this.translation.t("saturation.base"),
+      this.translation.t("saturation.low"),
+      this.translation.t("saturation.high"),
+      this.translation.t("saturation.desaturated"),
+    ];
+  }
+
   document = inject(DOCUMENT);
 
   currentState = 0;

--- a/projects/astral-accessibility/src/lib/controls/screen-mask.component.spec.ts
+++ b/projects/astral-accessibility/src/lib/controls/screen-mask.component.spec.ts
@@ -1,0 +1,38 @@
+import { TestBed } from "@angular/core/testing";
+import { ScreenMaskComponent } from "./screen-mask.component";
+import { AstralTranslationService } from "../astral-translation.service";
+
+describe("ScreenMaskComponent labels", () => {
+  let component: ScreenMaskComponent;
+  let translationService: AstralTranslationService;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [ScreenMaskComponent],
+    }).compileComponents();
+
+    translationService = TestBed.inject(AstralTranslationService);
+    const fixture = TestBed.createComponent(ScreenMaskComponent);
+    component = fixture.componentInstance;
+  });
+
+  it("returns English labels by default", () => {
+    expect(component.labels[0]).toBe("Screen Mask");
+    expect(component.labels[1]).toBe("Large Cursor");
+    expect(component.labels[2]).toBe("Reading Mask");
+  });
+
+  it("returns French labels after setLanguage('fr')", () => {
+    translationService.setLanguage("fr");
+    expect(component.labels[0]).toBe("Masque d'écran");
+    expect(component.labels[1]).toBe("Grand curseur");
+    expect(component.labels[2]).toBe("Masque de lecture");
+  });
+
+  it("returns Traditional Chinese labels after setLanguage('zh-Hant')", () => {
+    translationService.setLanguage("zh-Hant");
+    expect(component.labels[0]).toBe("螢幕遮罩");
+    expect(component.labels[1]).toBe("大型游標");
+    expect(component.labels[2]).toBe("閱讀遮罩");
+  });
+});

--- a/projects/astral-accessibility/src/lib/controls/screen-mask.component.ts
+++ b/projects/astral-accessibility/src/lib/controls/screen-mask.component.ts
@@ -1,6 +1,7 @@
 import { DOCUMENT, NgIf, NgClass } from "@angular/common";
 import { Component, Renderer2, inject } from "@angular/core";
 import { AstralCheckmarkSvgComponent } from "../util/astral-checksvg.component";
+import { AstralTranslationService } from "../astral-translation.service";
 
 @Component({
   selector: "astral-screen-mask",
@@ -42,7 +43,7 @@ import { AstralCheckmarkSvgComponent } from "../util/astral-checksvg.component";
           </div>
 
           <div class="state-dots-wrap">
-            <span>{{ states[currentState] }}</span>
+            <span>{{ labels[currentState] }}</span>
             <div
               class="dots"
               [ngClass]="{ inactive: states[currentState] === base }"
@@ -70,7 +71,18 @@ import { AstralCheckmarkSvgComponent } from "../util/astral-checksvg.component";
   imports: [NgIf, NgClass, AstralCheckmarkSvgComponent],
 })
 export class ScreenMaskComponent {
-  constructor(private renderer: Renderer2) {}
+  constructor(
+    private renderer: Renderer2,
+    private translation: AstralTranslationService,
+  ) {}
+
+  get labels(): string[] {
+    return [
+      this.translation.t("screenMask.base"),
+      this.translation.t("screenMask.largeCursor"),
+      this.translation.t("screenMask.readingMask"),
+    ];
+  }
 
   cursorY = 0;
   screenHeight: number = window.innerHeight;

--- a/projects/astral-accessibility/src/lib/controls/screen-reader.component.spec.ts
+++ b/projects/astral-accessibility/src/lib/controls/screen-reader.component.spec.ts
@@ -1,0 +1,48 @@
+import { TestBed } from "@angular/core/testing";
+import { ScreenReaderComponent } from "./screen-reader.component";
+import { AstralTranslationService } from "../astral-translation.service";
+
+describe("ScreenReaderComponent labels", () => {
+  let component: ScreenReaderComponent;
+  let translationService: AstralTranslationService;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [ScreenReaderComponent],
+    }).compileComponents();
+
+    translationService = TestBed.inject(AstralTranslationService);
+    const fixture = TestBed.createComponent(ScreenReaderComponent);
+    component = fixture.componentInstance;
+  });
+
+  it("returns English labels by default", () => {
+    expect(component.labels[0]).toBe("Screen Reader");
+    expect(component.labels[1]).toBe("Read Normal");
+    expect(component.labels[2]).toBe("Read Fast");
+    expect(component.labels[3]).toBe("Read Slow");
+    expect(component.unavailableLabel).toBe(
+      "Screen Reader unavailable on device",
+    );
+  });
+
+  it("returns French labels after setLanguage('fr')", () => {
+    translationService.setLanguage("fr");
+    expect(component.labels[0]).toBe("Lecteur d'écran");
+    expect(component.labels[1]).toBe("Lecture normale");
+    expect(component.labels[2]).toBe("Lecture rapide");
+    expect(component.labels[3]).toBe("Lecture lente");
+    expect(component.unavailableLabel).toBe(
+      "Lecteur d'écran indisponible sur cet appareil",
+    );
+  });
+
+  it("returns Traditional Chinese labels after setLanguage('zh-Hant')", () => {
+    translationService.setLanguage("zh-Hant");
+    expect(component.labels[0]).toBe("螢幕閱讀器");
+    expect(component.labels[1]).toBe("正常閱讀");
+    expect(component.labels[2]).toBe("快速閱讀");
+    expect(component.labels[3]).toBe("慢速閱讀");
+    expect(component.unavailableLabel).toBe("此裝置不支援螢幕閱讀器");
+  });
+});

--- a/projects/astral-accessibility/src/lib/controls/screen-reader.component.ts
+++ b/projects/astral-accessibility/src/lib/controls/screen-reader.component.ts
@@ -1,6 +1,8 @@
 import { DOCUMENT, NgIf, NgClass } from "@angular/common";
-import { Component, inject, Renderer2 } from "@angular/core";
+import { Component, inject, NgZone, Renderer2 } from "@angular/core";
+import { Subscription } from "rxjs";
 import { AstralCheckmarkSvgComponent } from "../util/astral-checksvg.component";
+import { AstralTranslationService } from "../astral-translation.service";
 
 @Component({
   selector: "astral-screen-reader",
@@ -56,7 +58,7 @@ import { AstralCheckmarkSvgComponent } from "../util/astral-checksvg.component";
 
           <div class="state-dots-wrap">
             <span>{{
-              synthesisAvailable ? states[currentState] : unavailableMessage
+              synthesisAvailable ? labels[currentState] : unavailableLabel
             }}</span>
             <div
               class="dots"
@@ -88,13 +90,31 @@ import { AstralCheckmarkSvgComponent } from "../util/astral-checksvg.component";
 })
 export class ScreenReaderComponent {
   globalListenFunction: Function;
+  private langSub: Subscription;
   speech = new SpeechSynthesisUtterance();
   userAgent = navigator.userAgent;
   isApple = false;
   isEdgeAndroid = false;
   synthesisAvailable = true;
 
-  constructor(private renderer: Renderer2) {}
+  constructor(
+    private renderer: Renderer2,
+    private translation: AstralTranslationService,
+    private ngZone: NgZone,
+  ) {}
+
+  get labels(): string[] {
+    return [
+      this.translation.t("screenReader.base"),
+      this.translation.t("screenReader.readNormal"),
+      this.translation.t("screenReader.readFast"),
+      this.translation.t("screenReader.readSlow"),
+    ];
+  }
+
+  get unavailableLabel(): string {
+    return this.translation.t("screenReader.unavailable");
+  }
 
   readText(x: number, y: number) {
     let element = document.elementFromPoint(x, y);
@@ -120,8 +140,6 @@ export class ScreenReaderComponent {
     isApple = false,
     isEdgeAndroid = false,
   ) {
-    const defaultVoice = "Daniel";
-
     // Note: Edge Android doesn't have any voices, but still works without setting the voice
     if (voices.length > 0 || isEdgeAndroid) {
       this.synthesisAvailable = true;
@@ -130,30 +148,35 @@ export class ScreenReaderComponent {
       return null;
     }
 
-    // use voice Daniel whenever available
-    const voice = voices.findIndex((v) => {
-      return v.name.toUpperCase().includes(defaultVoice.toUpperCase());
-    });
-    if (voice) {
-      this.synthesisAvailable = true;
-      return voices[voice];
+    const baseLang = this.translation.currentLang.split("-")[0];
+
+    // use voice Daniel whenever available (English only)
+    if (baseLang === "en") {
+      const danielIndex = voices.findIndex((v) =>
+        v.name.toUpperCase().includes("DANIEL"),
+      );
+      if (danielIndex) {
+        this.synthesisAvailable = true;
+        return voices[danielIndex];
+      }
     }
 
-    // if voice Daniel not found, then pick another default voice that is not Flo
+    // pick a voice matching the current language, avoiding Flo
+    let filtered = voices.filter((voice) =>
+      new RegExp(`^${baseLang}`, "i").test(voice.lang),
+    );
+    if (!filtered.length) {
+      return null;
+    }
     let i = 0;
-    voices = voices.filter((voice) => /en-US/i.test(voice.lang));
     while (
-      !voices[i].default &&
-      i < voices.length &&
-      !voices[i].voiceURI.toUpperCase().includes("FLO")
+      i < filtered.length &&
+      !filtered[i].default &&
+      !filtered[i].voiceURI.toUpperCase().includes("FLO")
     ) {
       i++;
     }
-    if (i < voices.length) {
-      return voices[i];
-    } else {
-      return voices[0] || null;
-    }
+    return filtered[i] ?? filtered[0] ?? null;
   }
 
   ngOnInit() {
@@ -178,7 +201,7 @@ export class ScreenReaderComponent {
       this.isApple,
       this.isEdgeAndroid,
     );
-    this.speech.lang = "en";
+    this.speech.lang = this.translation.currentLang;
     this.speech.rate = 1;
     this.speech.pitch = 1;
     this.speech.volume = 1;
@@ -187,14 +210,35 @@ export class ScreenReaderComponent {
     // https://www.bennadel.com/blog/3955-having-fun-with-the-speechsynthesis-api-in-angular-11-0-5.htm
     if (!voices.length) {
       speechSynthesis.addEventListener("voiceschanged", () => {
-        voices = speechSynthesis.getVoices();
-        this.speech.voice = this.getDefaultVoice(
-          voices,
-          this.isApple,
-          this.isEdgeAndroid,
-        );
+        this.ngZone.run(() => {
+          voices = speechSynthesis.getVoices();
+          this.speech.voice = this.getDefaultVoice(
+            voices,
+            this.isApple,
+            this.isEdgeAndroid,
+          );
+        });
       });
     }
+
+    this.langSub = this.translation.langChange.subscribe((lang) => {
+      this.ngZone.run(() => {
+        this.speech.lang = lang;
+        const currentVoices = speechSynthesis.getVoices();
+        if (currentVoices.length) {
+          this.speech.voice = this.getDefaultVoice(
+            currentVoices,
+            this.isApple,
+            this.isEdgeAndroid,
+          );
+        } else {
+          // voices not yet loaded — don't call getDefaultVoice (it would set
+          // synthesisAvailable = false); voiceschanged will pick the right
+          // voice once they arrive
+          this.speech.voice = null;
+        }
+      });
+    });
 
     // find the element that the user tapped/clicked on
     this.globalListenFunction = this.renderer.listen(
@@ -215,15 +259,14 @@ export class ScreenReaderComponent {
   }
 
   ngOnDestroy() {
-    // remove listener
-    this.globalListenFunction();
+    this.globalListenFunction?.();
+    this.langSub?.unsubscribe();
   }
 
   document = inject(DOCUMENT);
 
   currentState = 0;
   base = "Screen Reader";
-  unavailableMessage = "Screen Reader unavailable on device";
   states = [this.base, "Read Normal", "Read Fast", "Read Slow"];
 
   _style: HTMLStyleElement;

--- a/projects/astral-accessibility/src/lib/controls/text-size.component.spec.ts
+++ b/projects/astral-accessibility/src/lib/controls/text-size.component.spec.ts
@@ -1,0 +1,41 @@
+import { TestBed } from "@angular/core/testing";
+import { TextSizeComponent } from "./text-size.component";
+import { AstralTranslationService } from "../astral-translation.service";
+
+describe("TextSizeComponent labels", () => {
+  let component: TextSizeComponent;
+  let translationService: AstralTranslationService;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [TextSizeComponent],
+    }).compileComponents();
+
+    translationService = TestBed.inject(AstralTranslationService);
+    const fixture = TestBed.createComponent(TextSizeComponent);
+    component = fixture.componentInstance;
+  });
+
+  it("returns English labels by default", () => {
+    expect(component.labels[0]).toBe("Bigger Text");
+    expect(component.labels[1]).toBe("Medium Text");
+    expect(component.labels[2]).toBe("Large Text");
+    expect(component.labels[3]).toBe("Extra Large Text");
+  });
+
+  it("returns French labels after setLanguage('fr')", () => {
+    translationService.setLanguage("fr");
+    expect(component.labels[0]).toBe("Texte plus grand");
+    expect(component.labels[1]).toBe("Texte moyen");
+    expect(component.labels[2]).toBe("Grand texte");
+    expect(component.labels[3]).toBe("Très grand texte");
+  });
+
+  it("returns Traditional Chinese labels after setLanguage('zh-Hant')", () => {
+    translationService.setLanguage("zh-Hant");
+    expect(component.labels[0]).toBe("放大文字");
+    expect(component.labels[1]).toBe("中等文字");
+    expect(component.labels[2]).toBe("大型文字");
+    expect(component.labels[3]).toBe("超大文字");
+  });
+});

--- a/projects/astral-accessibility/src/lib/controls/text-size.component.ts
+++ b/projects/astral-accessibility/src/lib/controls/text-size.component.ts
@@ -1,6 +1,7 @@
 import { DOCUMENT, NgIf, NgClass } from "@angular/common";
 import { Component, inject } from "@angular/core";
 import { AstralCheckmarkSvgComponent } from "../util/astral-checksvg.component";
+import { AstralTranslationService } from "../astral-translation.service";
 
 @Component({
   selector: "astral-text-size",
@@ -44,7 +45,7 @@ import { AstralCheckmarkSvgComponent } from "../util/astral-checksvg.component";
           </div>
 
           <div class="state-dots-wrap">
-            <span>{{ states[currentState] }}</span>
+            <span>{{ labels[currentState] }}</span>
             <div
               class="dots"
               [ngClass]="{ inactive: states[currentState] === base }"
@@ -95,7 +96,7 @@ export class TextSizeComponent {
   // Options for the observer (which mutations to observe)
   config = { attributes: true, childList: true, subtree: true };
 
-  constructor() {
+  constructor(private translation: AstralTranslationService) {
     this.observer = new MutationObserver(() => {
       if (this._rescaleFrame !== null) cancelAnimationFrame(this._rescaleFrame);
       this._rescaleFrame = requestAnimationFrame(() => {
@@ -107,6 +108,15 @@ export class TextSizeComponent {
       });
     });
     /* No observer here, we don't want it to be on by default */
+  }
+
+  get labels(): string[] {
+    return [
+      this.translation.t("textSize.base"),
+      this.translation.t("textSize.medium"),
+      this.translation.t("textSize.large"),
+      this.translation.t("textSize.extraLarge"),
+    ];
   }
 
   updateTextSize(node: HTMLElement, scale: number, previousScale: number = 1) {

--- a/projects/astral-accessibility/src/lib/controls/text-spacing.component.spec.ts
+++ b/projects/astral-accessibility/src/lib/controls/text-spacing.component.spec.ts
@@ -1,0 +1,41 @@
+import { TestBed } from "@angular/core/testing";
+import { TextSpacingComponent } from "./text-spacing.component";
+import { AstralTranslationService } from "../astral-translation.service";
+
+describe("TextSpacingComponent labels", () => {
+  let component: TextSpacingComponent;
+  let translationService: AstralTranslationService;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [TextSpacingComponent],
+    }).compileComponents();
+
+    translationService = TestBed.inject(AstralTranslationService);
+    const fixture = TestBed.createComponent(TextSpacingComponent);
+    component = fixture.componentInstance;
+  });
+
+  it("returns English labels by default", () => {
+    expect(component.labels[0]).toBe("Text Spacing");
+    expect(component.labels[1]).toBe("Light Spacing");
+    expect(component.labels[2]).toBe("Moderate Spacing");
+    expect(component.labels[3]).toBe("Heavy Spacing");
+  });
+
+  it("returns French labels after setLanguage('fr')", () => {
+    translationService.setLanguage("fr");
+    expect(component.labels[0]).toBe("Espacement du texte");
+    expect(component.labels[1]).toBe("Espacement léger");
+    expect(component.labels[2]).toBe("Espacement modéré");
+    expect(component.labels[3]).toBe("Espacement important");
+  });
+
+  it("returns Traditional Chinese labels after setLanguage('zh-Hant')", () => {
+    translationService.setLanguage("zh-Hant");
+    expect(component.labels[0]).toBe("文字間距");
+    expect(component.labels[1]).toBe("輕度間距");
+    expect(component.labels[2]).toBe("中度間距");
+    expect(component.labels[3]).toBe("重度間距");
+  });
+});

--- a/projects/astral-accessibility/src/lib/controls/text-spacing.component.ts
+++ b/projects/astral-accessibility/src/lib/controls/text-spacing.component.ts
@@ -1,6 +1,7 @@
 import { DOCUMENT, NgIf, NgClass } from "@angular/common";
 import { Component, inject } from "@angular/core";
 import { AstralCheckmarkSvgComponent } from "../util/astral-checksvg.component";
+import { AstralTranslationService } from "../astral-translation.service";
 
 @Component({
   selector: "astral-text-spacing",
@@ -44,7 +45,7 @@ import { AstralCheckmarkSvgComponent } from "../util/astral-checksvg.component";
           </div>
 
           <div class="state-dots-wrap">
-            <span>{{ states[currentState] }}</span>
+            <span>{{ labels[currentState] }}</span>
             <div
               class="dots"
               [ngClass]="{ inactive: states[currentState] === base }"
@@ -76,6 +77,17 @@ import { AstralCheckmarkSvgComponent } from "../util/astral-checksvg.component";
   imports: [NgIf, NgClass, AstralCheckmarkSvgComponent],
 })
 export class TextSpacingComponent {
+  constructor(private translation: AstralTranslationService) {}
+
+  get labels(): string[] {
+    return [
+      this.translation.t("textSpacing.base"),
+      this.translation.t("textSpacing.light"),
+      this.translation.t("textSpacing.moderate"),
+      this.translation.t("textSpacing.heavy"),
+    ];
+  }
+
   document = inject(DOCUMENT);
 
   currentState = 0;

--- a/projects/astral-accessibility/src/lib/i18n/en.json
+++ b/projects/astral-accessibility/src/lib/i18n/en.json
@@ -1,0 +1,36 @@
+{
+  "contrast.base": "Contrast",
+  "contrast.invert": "Invert",
+  "contrast.high": "High Contrast",
+  "contrast.darkHigh": "Dark High Contrast",
+
+  "screenReader.base": "Screen Reader",
+  "screenReader.readNormal": "Read Normal",
+  "screenReader.readFast": "Read Fast",
+  "screenReader.readSlow": "Read Slow",
+  "screenReader.unavailable": "Screen Reader unavailable on device",
+
+  "saturation.base": "Saturation",
+  "saturation.low": "Low Saturation",
+  "saturation.high": "High Saturation",
+  "saturation.desaturated": "Desaturated",
+
+  "textSize.base": "Bigger Text",
+  "textSize.medium": "Medium Text",
+  "textSize.large": "Large Text",
+  "textSize.extraLarge": "Extra Large Text",
+
+  "textSpacing.base": "Text Spacing",
+  "textSpacing.light": "Light Spacing",
+  "textSpacing.moderate": "Moderate Spacing",
+  "textSpacing.heavy": "Heavy Spacing",
+
+  "screenMask.base": "Screen Mask",
+  "screenMask.largeCursor": "Large Cursor",
+  "screenMask.readingMask": "Reading Mask",
+
+  "lineHeight.base": "Line Height",
+  "lineHeight.light": "Light Height",
+  "lineHeight.moderate": "Moderate Height",
+  "lineHeight.heavy": "Heavy Height"
+}

--- a/projects/astral-accessibility/src/lib/i18n/fr.json
+++ b/projects/astral-accessibility/src/lib/i18n/fr.json
@@ -1,0 +1,36 @@
+{
+  "contrast.base": "Contraste",
+  "contrast.invert": "Inverser",
+  "contrast.high": "Contraste élevé",
+  "contrast.darkHigh": "Contraste élevé sombre",
+
+  "screenReader.base": "Lecteur d'écran",
+  "screenReader.readNormal": "Lecture normale",
+  "screenReader.readFast": "Lecture rapide",
+  "screenReader.readSlow": "Lecture lente",
+  "screenReader.unavailable": "Lecteur d'écran indisponible sur cet appareil",
+
+  "saturation.base": "Saturation",
+  "saturation.low": "Faible saturation",
+  "saturation.high": "Haute saturation",
+  "saturation.desaturated": "Désaturé",
+
+  "textSize.base": "Texte plus grand",
+  "textSize.medium": "Texte moyen",
+  "textSize.large": "Grand texte",
+  "textSize.extraLarge": "Très grand texte",
+
+  "textSpacing.base": "Espacement du texte",
+  "textSpacing.light": "Espacement léger",
+  "textSpacing.moderate": "Espacement modéré",
+  "textSpacing.heavy": "Espacement important",
+
+  "screenMask.base": "Masque d'écran",
+  "screenMask.largeCursor": "Grand curseur",
+  "screenMask.readingMask": "Masque de lecture",
+
+  "lineHeight.base": "Hauteur de ligne",
+  "lineHeight.light": "Hauteur légère",
+  "lineHeight.moderate": "Hauteur modérée",
+  "lineHeight.heavy": "Hauteur importante"
+}

--- a/projects/astral-accessibility/src/lib/i18n/zh-Hant.json
+++ b/projects/astral-accessibility/src/lib/i18n/zh-Hant.json
@@ -1,0 +1,36 @@
+{
+  "contrast.base": "對比度",
+  "contrast.invert": "反轉",
+  "contrast.high": "高對比度",
+  "contrast.darkHigh": "深色高對比度",
+
+  "screenReader.base": "螢幕閱讀器",
+  "screenReader.readNormal": "正常閱讀",
+  "screenReader.readFast": "快速閱讀",
+  "screenReader.readSlow": "慢速閱讀",
+  "screenReader.unavailable": "此裝置不支援螢幕閱讀器",
+
+  "saturation.base": "飽和度",
+  "saturation.low": "低飽和度",
+  "saturation.high": "高飽和度",
+  "saturation.desaturated": "去飽和",
+
+  "textSize.base": "放大文字",
+  "textSize.medium": "中等文字",
+  "textSize.large": "大型文字",
+  "textSize.extraLarge": "超大文字",
+
+  "textSpacing.base": "文字間距",
+  "textSpacing.light": "輕度間距",
+  "textSpacing.moderate": "中度間距",
+  "textSpacing.heavy": "重度間距",
+
+  "screenMask.base": "螢幕遮罩",
+  "screenMask.largeCursor": "大型游標",
+  "screenMask.readingMask": "閱讀遮罩",
+
+  "lineHeight.base": "行高",
+  "lineHeight.light": "輕度行高",
+  "lineHeight.moderate": "中度行高",
+  "lineHeight.heavy": "重度行高"
+}

--- a/projects/astral-accessibility/src/main.ts
+++ b/projects/astral-accessibility/src/main.ts
@@ -2,6 +2,7 @@ import { DOCUMENT } from "@angular/common";
 import { createCustomElement } from "@angular/elements";
 import { createApplication } from "@angular/platform-browser";
 import { AstralAccessibilityComponent } from "./lib/astral-accessibility.component";
+import { AstralTranslationService } from "./lib/astral-translation.service";
 import "zone.js";
 
 (window as any).initializeAstral = async function initializeAstral(
@@ -38,6 +39,11 @@ import "zone.js";
       JSON.stringify(features),
     );
     doc.body.appendChild(astralAccessibilityElement);
+
+    const translationService = app.injector.get(AstralTranslationService);
+    (window as any).astralSetLanguage = (lang: string) => {
+      translationService.setLanguage(lang);
+    };
   } catch (err) {
     console.error(err);
   }

--- a/projects/demo/demo-translations.js
+++ b/projects/demo/demo-translations.js
@@ -1,0 +1,455 @@
+export const DEMO_TRANSLATIONS = {
+  en: {
+    nav: {
+      home: "Home",
+      screenReader: "Screen Reader",
+      contrast: "Contrast",
+      saturation: "Saturation",
+      biggerText: "Bigger Text",
+      textSpacing: "Text Spacing",
+      screenMask: "Screen Mask",
+      lineHeight: "Line Height",
+    },
+    home: {
+      h2: "Welcome",
+      subtitle:
+        "Astral Accessibility is a widget that provides reading and visual accessibility tools for web applications. Use the button in the bottom-right corner to open the panel and try each feature.",
+      h3Features: "Features",
+      featuresIntro:
+        "Navigate to each feature page to see the tool in action on a dedicated page.",
+      featureScreenReaderDesc: "reads out text when you click on elements",
+      featureContrastDesc: "high-contrast and dark modes for better legibility",
+      featureSaturationDesc: "adjust colour saturation or switch to greyscale",
+      featureBiggerTextDesc: "scale text up to Medium, Large, or Extra Large",
+      featureTextSpacingDesc: "increase letter spacing for readability",
+      featureScreenMaskDesc:
+        "dim the screen with a focus band that follows your cursor",
+      featureLineHeightDesc: "increase vertical spacing between lines",
+      h3About: "About this demo",
+      aboutText:
+        "Each page contains text so you can observe how the accessibility tools affect real content. Enable a setting, then navigate between pages to confirm the setting persists.",
+    },
+    screenReader: {
+      h2: "Screen Reader",
+      subtitle:
+        "The screen reader reads out content when you click on any element. If an aria-label is present it uses that; otherwise it reads the element's visible text. Three speeds are available: normal, fast, and slow.",
+      h3TryIt: "Try it",
+      tryItP1:
+        "Enable the Screen Reader from the widget, then click anywhere on this page. Headings, paragraphs, links, and labelled inputs should all be read aloud.",
+      tryItP2:
+        "Assistive technology benefits users with low vision, dyslexia, and attention difficulties. By hearing content read back, users can confirm what they are interacting with without needing to read every word on screen.",
+      h3AriaDemo: "Aria label demo",
+      ariaP:
+        "The button below has an aria-label that differs from its visible text. The screen reader should speak the label, not the text.",
+      buttonText: "Sign up",
+      buttonAriaLabel: "Submit the registration form",
+      h3PlainText: "Plain text demo",
+      plainP1:
+        "This paragraph has no special markup. Clicking it should read the raw text content aloud at the currently selected speed.",
+      plainP2:
+        "Accessibility is not a feature — it is a quality. Building inclusive interfaces ensures that every user, regardless of ability, can engage with digital content on equal footing.",
+    },
+    contrast: {
+      h2: "Contrast",
+      subtitle:
+        "The contrast tool modifies background and foreground colours to increase the difference between text and its surroundings. Three modes are available: invert colours, high contrast, and dark high contrast.",
+      h3WhyMatters: "Why contrast matters",
+      whyP1:
+        "Low contrast between text and background is one of the most common barriers for users with low vision or colour blindness. WCAG 2.1 requires a contrast ratio of at least 4.5:1 for normal text and 3:1 for large text.",
+      whyP2:
+        "High-contrast modes benefit users in bright environments too — sunlight reflecting off a screen can reduce effective contrast significantly.",
+      h3Enable: "Enable and compare",
+      enableP1:
+        "Open the accessibility widget and cycle through the contrast options. Observe how the background and text colours change on this page and in the navigation bar above.",
+      enableP2:
+        "After switching modes, navigate to another feature page and back to confirm the contrast setting is preserved across navigation.",
+    },
+    saturation: {
+      h2: "Saturation",
+      subtitle:
+        "The saturation tool adjusts how vivid the colours appear on screen. Three modes let you lower saturation, increase it, or remove colour entirely for a greyscale view.",
+      h3WhoBenefits: "Who benefits",
+      whoP1:
+        "Users with colour vision deficiency may find reduced or altered saturation easier to distinguish. Greyscale mode removes colour as a carrier of meaning entirely, which is useful for testing whether a design is accessible without relying on colour alone.",
+      whoP2:
+        "Oversaturation can be useful for users with certain visual processing differences who perceive low-saturation displays as washed out.",
+      h3ColoredDemo: "Coloured content demo",
+      blueText: "This sentence is rendered in blue.",
+      orangeText: "This sentence is rendered in orange-red.",
+      greenText: "This sentence is rendered in green.",
+      coloredP:
+        "Cycle through the saturation settings from the widget and observe how the coloured sentences above change. Greyscale mode should render all three paragraphs in similar shades of grey.",
+    },
+    biggerText: {
+      h2: "Bigger Text",
+      subtitle:
+        "The Bigger Text tool scales all text on the page. Three levels are available: Medium (1.2×), Large (1.5×), and Extra Large (1.8×).",
+      h3HowWorks: "How it works",
+      howP1:
+        "Text scaling is applied by traversing the DOM and adjusting the computed font size of each text-bearing element. A MutationObserver watches for new nodes added during navigation so that dynamically rendered content is scaled too.",
+      howP2:
+        "Enable a text size level, then navigate to another page and back. The font should remain at the selected size without growing larger on each navigation.",
+      h3SampleText: "Sample text at various sizes",
+      sample12px: "This paragraph uses a 12px base font size.",
+      sample16px: "This paragraph uses a 16px base font size.",
+      sample20px: "This paragraph uses a 20px base font size.",
+      h3Navigate: "Navigate and return",
+      navigateP:
+        "Set the text size to Large, navigate to the Screen Reader page, then return here. The paragraph sizes above should be exactly 1.5× their original values — not 1.5× compounded over multiple navigations.",
+    },
+    textSpacing: {
+      h2: "Text Spacing",
+      subtitle:
+        "The Text Spacing tool increases the letter spacing between characters, making dense text easier to scan and read.",
+      h3Benefits: "Benefits for readers",
+      benefitsP1:
+        "Wider letter spacing benefits users with dyslexia, who often report that tightly packed characters blur together. It also helps users reading in a second language, where individual character recognition plays a larger role in comprehension.",
+      benefitsP2:
+        "WCAG 2.1 Success Criterion 1.4.12 requires that no loss of content occurs when letter spacing is increased to at least 0.12× the font size. This tool goes beyond that baseline.",
+      h3DenseDemo: "Dense text demo",
+      denseIntro:
+        "The following paragraph is intentionally compact. Enable Text Spacing from the widget and observe how the characters spread apart:",
+      denseText:
+        "Accessibility standards exist to ensure that the broadest possible audience can use digital interfaces effectively. When developers implement these standards consistently, the result is a product that works for everyone — not just the majority.",
+    },
+    screenMask: {
+      h2: "Screen Mask",
+      subtitle:
+        "The Screen Mask dims the background and highlights a horizontal band that follows your cursor as you move it up and down the page.",
+      h3WhoHelps: "Who it helps",
+      whoP1:
+        "Users with attention deficit disorders, visual tracking difficulties, or photosensitivity benefit from isolating a single line of focus. The mask reduces the cognitive load of filtering out surrounding content while reading.",
+      whoP2:
+        "It is also useful on information-dense pages — such as tables or code listings — where accidentally jumping to the wrong row is a common frustration.",
+      h3TryHere: "Try it here",
+      tryP1:
+        "Enable the Screen Mask from the widget, then move your cursor slowly down this page. The focus band should track your vertical position, dimming everything above and below the highlighted area.",
+      tryP2:
+        "Move your cursor quickly — the band should follow smoothly without lag. Then navigate to another page and back to confirm the mask remains active.",
+      tryP3:
+        "The following lines are spaced generously to make the focus band easier to observe as it moves:",
+      line1: "Line one — move your cursor here.",
+      line2: "Line two — now move your cursor here.",
+      line3: "Line three — and now here.",
+    },
+    lineHeight: {
+      h2: "Line Height",
+      subtitle:
+        "The Line Height tool increases the vertical spacing between lines of text, making paragraphs easier to follow from one line to the next.",
+      h3WhyMatters: "Why spacing matters",
+      whyP1:
+        "Insufficient line height forces the eye to work harder when moving from the end of one line to the beginning of the next. For users with low vision or cognitive differences, this extra effort accumulates across a long document and leads to faster fatigue.",
+      whyP2:
+        "WCAG 2.1 Success Criterion 1.4.12 specifies a minimum line height of 1.5× the font size. Many designs fall short of this baseline. This tool lets users override the page's default spacing to meet their own needs.",
+      h3DenseDemo: "Dense paragraph demo",
+      denseP:
+        "This paragraph has a deliberately tight line height of 1.2. Enable Line Height from the accessibility widget and watch this paragraph open up. The increased spacing should make it noticeably easier to read through to the end of each line without losing your place.",
+      h3NormalPara: "Normal paragraph",
+      normalP:
+        "This paragraph uses the default line height set by the stylesheet. Use it as a reference to compare how the tight paragraph above changes relative to unmodified content when you adjust the line height setting.",
+    },
+  },
+
+  fr: {
+    nav: {
+      home: "Accueil",
+      screenReader: "Lecteur d'écran",
+      contrast: "Contraste",
+      saturation: "Saturation",
+      biggerText: "Texte plus grand",
+      textSpacing: "Espacement du texte",
+      screenMask: "Masque d'écran",
+      lineHeight: "Hauteur de ligne",
+    },
+    home: {
+      h2: "Bienvenue",
+      subtitle:
+        "Astral Accessibility est un widget qui fournit des outils d'accessibilité de lecture et visuels pour les applications web. Utilisez le bouton en bas à droite pour ouvrir le panneau et essayer chaque fonctionnalité.",
+      h3Features: "Fonctionnalités",
+      featuresIntro:
+        "Accédez à chaque page de fonctionnalité pour voir l'outil en action sur une page dédiée.",
+      featureScreenReaderDesc:
+        "lit le texte lorsque vous cliquez sur des éléments",
+      featureContrastDesc:
+        "modes à contraste élevé et sombre pour une meilleure lisibilité",
+      featureSaturationDesc:
+        "ajuster la saturation des couleurs ou passer en niveaux de gris",
+      featureBiggerTextDesc: "agrandir le texte en Moyen, Grand ou Très grand",
+      featureTextSpacingDesc:
+        "augmenter l'espacement des lettres pour une meilleure lisibilité",
+      featureScreenMaskDesc:
+        "assombrir l'écran avec une bande de focus qui suit votre curseur",
+      featureLineHeightDesc: "augmenter l'espacement vertical entre les lignes",
+      h3About: "À propos de cette démo",
+      aboutText:
+        "Chaque page contient du texte pour vous permettre d'observer comment les outils d'accessibilité affectent le contenu réel. Activez un paramètre, puis naviguez entre les pages pour confirmer que le paramètre persiste.",
+    },
+    screenReader: {
+      h2: "Lecteur d'écran",
+      subtitle:
+        "Le lecteur d'écran lit le contenu lorsque vous cliquez sur un élément. Si un aria-label est présent, il l'utilise ; sinon, il lit le texte visible de l'élément. Trois vitesses sont disponibles : normale, rapide et lente.",
+      h3TryIt: "Essayez",
+      tryItP1:
+        "Activez le lecteur d'écran depuis le widget, puis cliquez n'importe où sur cette page. Les titres, paragraphes, liens et entrées étiquetées devraient tous être lus à voix haute.",
+      tryItP2:
+        "La technologie d'assistance bénéficie aux utilisateurs ayant une basse vision, une dyslexie et des difficultés d'attention. En entendant le contenu lu, les utilisateurs peuvent confirmer ce avec quoi ils interagissent sans avoir besoin de lire chaque mot à l'écran.",
+      h3AriaDemo: "Démo d'étiquette aria",
+      ariaP:
+        "Le bouton ci-dessous a un aria-label différent de son texte visible. Le lecteur d'écran devrait lire l'étiquette, pas le texte.",
+      buttonText: "S'inscrire",
+      buttonAriaLabel: "Soumettre le formulaire d'inscription",
+      h3PlainText: "Démo de texte brut",
+      plainP1:
+        "Ce paragraphe n'a pas de balisage spécial. Cliquer dessus devrait lire le texte brut à voix haute à la vitesse actuellement sélectionnée.",
+      plainP2:
+        "L'accessibilité n'est pas une fonctionnalité — c'est une qualité. Construire des interfaces inclusives garantit que chaque utilisateur, quelle que soit sa capacité, peut interagir avec le contenu numérique sur un pied d'égalité.",
+    },
+    contrast: {
+      h2: "Contraste",
+      subtitle:
+        "L'outil de contraste modifie les couleurs d'arrière-plan et de premier plan pour augmenter la différence entre le texte et son environnement. Trois modes sont disponibles : inverser les couleurs, contraste élevé et contraste élevé sombre.",
+      h3WhyMatters: "Pourquoi le contraste est important",
+      whyP1:
+        "Un faible contraste entre le texte et l'arrière-plan est l'un des obstacles les plus courants pour les utilisateurs ayant une basse vision ou un daltonisme. WCAG 2.1 exige un rapport de contraste d'au moins 4,5:1 pour le texte normal et 3:1 pour le grand texte.",
+      whyP2:
+        "Les modes à contraste élevé bénéficient également aux utilisateurs dans des environnements lumineux — le soleil reflété sur un écran peut réduire considérablement le contraste effectif.",
+      h3Enable: "Activer et comparer",
+      enableP1:
+        "Ouvrez le widget d'accessibilité et parcourez les options de contraste. Observez comment les couleurs d'arrière-plan et de texte changent sur cette page et dans la barre de navigation ci-dessus.",
+      enableP2:
+        "Après avoir changé de mode, naviguez vers une autre page de fonctionnalité et revenez pour confirmer que le paramètre de contraste est préservé lors de la navigation.",
+    },
+    saturation: {
+      h2: "Saturation",
+      subtitle:
+        "L'outil de saturation ajuste la vivacité des couleurs à l'écran. Trois modes vous permettent de diminuer la saturation, de l'augmenter ou de supprimer entièrement la couleur pour une vue en niveaux de gris.",
+      h3WhoBenefits: "Qui en bénéficie",
+      whoP1:
+        "Les utilisateurs avec une déficience de la vision des couleurs peuvent trouver une saturation réduite ou altérée plus facile à distinguer. Le mode niveaux de gris supprime complètement la couleur comme vecteur de sens, ce qui est utile pour tester si un design est accessible sans se fier uniquement à la couleur.",
+      whoP2:
+        "La sursaturation peut être utile pour les utilisateurs ayant certaines différences de traitement visuel qui perçoivent les écrans à faible saturation comme délavés.",
+      h3ColoredDemo: "Démo de contenu coloré",
+      blueText: "Cette phrase est rendue en bleu.",
+      orangeText: "Cette phrase est rendue en orange-rouge.",
+      greenText: "Cette phrase est rendue en vert.",
+      coloredP:
+        "Parcourez les paramètres de saturation depuis le widget et observez comment les phrases colorées ci-dessus changent. Le mode niveaux de gris devrait rendre les trois paragraphes dans des teintes de gris similaires.",
+    },
+    biggerText: {
+      h2: "Texte plus grand",
+      subtitle:
+        "L'outil Texte plus grand met à l'échelle tout le texte sur la page. Trois niveaux sont disponibles : Moyen (1,2×), Grand (1,5×) et Très grand (1,8×).",
+      h3HowWorks: "Comment ça fonctionne",
+      howP1:
+        "La mise à l'échelle du texte est appliquée en parcourant le DOM et en ajustant la taille de police calculée de chaque élément portant du texte. Un MutationObserver surveille les nouveaux nœuds ajoutés lors de la navigation pour que le contenu rendu dynamiquement soit également mis à l'échelle.",
+      howP2:
+        "Activez un niveau de taille de texte, puis naviguez vers une autre page et revenez. La police devrait rester à la taille sélectionnée sans grossir à chaque navigation.",
+      h3SampleText: "Exemples de texte à différentes tailles",
+      sample12px: "Ce paragraphe utilise une taille de police de base de 12px.",
+      sample16px: "Ce paragraphe utilise une taille de police de base de 16px.",
+      sample20px: "Ce paragraphe utilise une taille de police de base de 20px.",
+      h3Navigate: "Naviguer et revenir",
+      navigateP:
+        "Réglez la taille du texte sur Grand, naviguez vers la page Lecteur d'écran, puis revenez ici. Les tailles de paragraphe ci-dessus devraient être exactement 1,5× leurs valeurs d'origine — pas 1,5× composé sur plusieurs navigations.",
+    },
+    textSpacing: {
+      h2: "Espacement du texte",
+      subtitle:
+        "L'outil Espacement du texte augmente l'espacement des lettres entre les caractères, rendant le texte dense plus facile à parcourir et à lire.",
+      h3Benefits: "Avantages pour les lecteurs",
+      benefitsP1:
+        "Un espacement des lettres plus large bénéficie aux utilisateurs dyslexiques, qui signalent souvent que les caractères serrés se confondent. Il aide également les utilisateurs lisant dans une deuxième langue, où la reconnaissance individuelle des caractères joue un rôle plus important dans la compréhension.",
+      benefitsP2:
+        "Le critère de succès WCAG 2.1 1.4.12 exige qu'aucune perte de contenu ne se produise lorsque l'espacement des lettres est augmenté à au moins 0,12× la taille de police. Cet outil va au-delà de cette base.",
+      h3DenseDemo: "Démo de texte dense",
+      denseIntro:
+        "Le paragraphe suivant est intentionnellement compact. Activez l'Espacement du texte depuis le widget et observez comment les caractères s'écartent :",
+      denseText:
+        "Les normes d'accessibilité existent pour garantir que le plus large public possible peut utiliser les interfaces numériques efficacement. Lorsque les développeurs appliquent ces normes de manière cohérente, le résultat est un produit qui fonctionne pour tous — pas seulement pour la majorité.",
+    },
+    screenMask: {
+      h2: "Masque d'écran",
+      subtitle:
+        "Le Masque d'écran assombrit l'arrière-plan et met en évidence une bande horizontale qui suit votre curseur lorsque vous le déplacez de haut en bas sur la page.",
+      h3WhoHelps: "À qui ça aide",
+      whoP1:
+        "Les utilisateurs souffrant de troubles déficitaires de l'attention, de difficultés de suivi visuel ou de photosensibilité bénéficient de l'isolation d'une seule ligne de focus. Le masque réduit la charge cognitive liée au filtrage du contenu environnant lors de la lecture.",
+      whoP2:
+        "Il est également utile sur les pages à forte densité d'informations — comme les tableaux ou les listes de code — où sauter accidentellement à la mauvaise ligne est une frustration courante.",
+      h3TryHere: "Essayez ici",
+      tryP1:
+        "Activez le Masque d'écran depuis le widget, puis déplacez lentement votre curseur vers le bas de cette page. La bande de focus devrait suivre votre position verticale, assombrissant tout ce qui est au-dessus et en dessous de la zone mise en évidence.",
+      tryP2:
+        "Déplacez rapidement votre curseur — la bande devrait suivre en douceur sans décalage. Naviguez ensuite vers une autre page et revenez pour confirmer que le masque reste actif.",
+      tryP3:
+        "Les lignes suivantes sont espacées généreusement pour faciliter l'observation de la bande de focus lors de ses déplacements :",
+      line1: "Ligne un — déplacez votre curseur ici.",
+      line2: "Ligne deux — déplacez maintenant votre curseur ici.",
+      line3: "Ligne trois — et maintenant ici.",
+    },
+    lineHeight: {
+      h2: "Hauteur de ligne",
+      subtitle:
+        "L'outil Hauteur de ligne augmente l'espacement vertical entre les lignes de texte, rendant les paragraphes plus faciles à suivre d'une ligne à l'autre.",
+      h3WhyMatters: "Pourquoi l'espacement est important",
+      whyP1:
+        "Une hauteur de ligne insuffisante force l'œil à travailler davantage lors du passage de la fin d'une ligne au début de la suivante. Pour les utilisateurs ayant une basse vision ou des différences cognitives, cet effort supplémentaire s'accumule sur un long document et conduit à une fatigue plus rapide.",
+      whyP2:
+        "Le critère de succès WCAG 2.1 1.4.12 spécifie une hauteur de ligne minimale de 1,5× la taille de police. De nombreux designs sont en deçà de cette base. Cet outil permet aux utilisateurs de remplacer l'espacement par défaut de la page selon leurs propres besoins.",
+      h3DenseDemo: "Démo de paragraphe dense",
+      denseP:
+        "Ce paragraphe a une hauteur de ligne délibérément serrée de 1,2. Activez la Hauteur de ligne depuis le widget d'accessibilité et observez ce paragraphe s'ouvrir. L'espacement accru devrait rendre notablement plus facile la lecture jusqu'à la fin de chaque ligne sans perdre sa place.",
+      h3NormalPara: "Paragraphe normal",
+      normalP:
+        "Ce paragraphe utilise la hauteur de ligne par défaut définie par la feuille de style. Utilisez-le comme référence pour comparer comment le paragraphe serré ci-dessus change par rapport au contenu non modifié lorsque vous ajustez le paramètre de hauteur de ligne.",
+    },
+  },
+
+  "zh-Hant": {
+    nav: {
+      home: "首頁",
+      screenReader: "螢幕閱讀器",
+      contrast: "對比度",
+      saturation: "飽和度",
+      biggerText: "放大文字",
+      textSpacing: "文字間距",
+      screenMask: "螢幕遮罩",
+      lineHeight: "行高",
+    },
+    home: {
+      h2: "歡迎",
+      subtitle:
+        "Astral Accessibility 是一個為網頁應用程式提供閱讀和視覺無障礙工具的小工具。使用右下角的按鈕開啟面板並嘗試每項功能。",
+      h3Features: "功能",
+      featuresIntro: "前往每個功能頁面，在專屬頁面上查看工具的實際效果。",
+      featureScreenReaderDesc: "當您點擊元素時讀出文字",
+      featureContrastDesc: "高對比度和深色模式，提高可讀性",
+      featureSaturationDesc: "調整色彩飽和度或切換至灰階",
+      featureBiggerTextDesc: "將文字放大至中等、大型或超大",
+      featureTextSpacingDesc: "增加字母間距以提高可讀性",
+      featureScreenMaskDesc: "以跟隨游標的焦點帶使螢幕變暗",
+      featureLineHeightDesc: "增加行間的垂直間距",
+      h3About: "關於此示範",
+      aboutText:
+        "每個頁面都包含文字，讓您觀察無障礙工具如何影響真實內容。啟用一個設定，然後在頁面之間導航，確認設定持續有效。",
+    },
+    screenReader: {
+      h2: "螢幕閱讀器",
+      subtitle:
+        "當您點擊任何元素時，螢幕閱讀器會讀出內容。若存在 aria-label，則使用它；否則讀取元素的可見文字。提供三種速度：正常、快速和慢速。",
+      h3TryIt: "試試看",
+      tryItP1:
+        "從小工具啟用螢幕閱讀器，然後點擊此頁面上的任何位置。標題、段落、連結和已標記的輸入框都應被大聲朗讀。",
+      tryItP2:
+        "輔助技術有助於視力低下、閱讀障礙和注意力困難的使用者。透過聆聽內容被讀出，使用者可以確認他們正在互動的內容，而不需要閱讀螢幕上的每個字。",
+      h3AriaDemo: "aria 標籤示範",
+      ariaP:
+        "以下按鈕的 aria-label 與其可見文字不同。螢幕閱讀器應朗讀標籤，而非文字。",
+      buttonText: "註冊",
+      buttonAriaLabel: "提交註冊表單",
+      h3PlainText: "純文字示範",
+      plainP1:
+        "此段落沒有特殊標記。點擊它應以當前選擇的速度大聲讀出原始文字內容。",
+      plainP2:
+        "無障礙不是一項功能——它是一種品質。建立包容性介面確保每位使用者，無論能力如何，都能在平等的基礎上與數位內容互動。",
+    },
+    contrast: {
+      h2: "對比度",
+      subtitle:
+        "對比度工具修改背景和前景顏色，以增加文字與周圍環境之間的差異。提供三種模式：反轉顏色、高對比度和深色高對比度。",
+      h3WhyMatters: "為什麼對比度很重要",
+      whyP1:
+        "文字和背景之間的低對比度是視力低下或色盲使用者最常見的障礙之一。WCAG 2.1 要求普通文字的對比度至少為 4.5:1，大型文字為 3:1。",
+      whyP2:
+        "高對比度模式也有助於在明亮環境中的使用者——陽光反射在螢幕上可以顯著降低有效對比度。",
+      h3Enable: "啟用並比較",
+      enableP1:
+        "開啟無障礙小工具並循環瀏覽對比度選項。觀察此頁面和上方導航欄中背景和文字顏色的變化。",
+      enableP2:
+        "切換模式後，導航到另一個功能頁面並返回，確認對比度設定在導航過程中得以保留。",
+    },
+    saturation: {
+      h2: "飽和度",
+      subtitle:
+        "飽和度工具調整螢幕上顯示的顏色鮮豔程度。三種模式讓您降低飽和度、增加飽和度，或完全移除顏色以呈現灰階視圖。",
+      h3WhoBenefits: "誰能受益",
+      whoP1:
+        "色覺障礙的使用者可能發現降低或改變的飽和度更容易辨別。灰階模式完全移除顏色作為意義的載體，這對於測試設計是否在不依賴顏色的情況下也能無障礙很有用。",
+      whoP2:
+        "對於某些視覺處理差異的使用者，過度飽和可能很有用，他們認為低飽和度的顯示器看起來很黯淡。",
+      h3ColoredDemo: "彩色內容示範",
+      blueText: "這句話以藍色呈現。",
+      orangeText: "這句話以橙紅色呈現。",
+      greenText: "這句話以綠色呈現。",
+      coloredP:
+        "從小工具循環瀏覽飽和度設定，觀察上方彩色句子的變化。灰階模式應將三個段落都以相似的灰色調呈現。",
+    },
+    biggerText: {
+      h2: "放大文字",
+      subtitle:
+        "放大文字工具縮放頁面上的所有文字。提供三個級別：中等（1.2×）、大（1.5×）和超大（1.8×）。",
+      h3HowWorks: "運作方式",
+      howP1:
+        "文字縮放透過遍歷 DOM 並調整每個含文字元素的計算字體大小來應用。MutationObserver 監視導航過程中新增的節點，以便動態渲染的內容也能被縮放。",
+      howP2:
+        "啟用文字大小級別，然後導航到另一個頁面並返回。字體應保持在選定的大小，而不會在每次導航時增大。",
+      h3SampleText: "各種大小的文字示例",
+      sample12px: "此段落使用 12px 的基本字體大小。",
+      sample16px: "此段落使用 16px 的基本字體大小。",
+      sample20px: "此段落使用 20px 的基本字體大小。",
+      h3Navigate: "導航並返回",
+      navigateP:
+        "將文字大小設為大，導航到螢幕閱讀器頁面，然後返回此處。上方的段落大小應恰好是其原始值的 1.5×——而不是在多次導航中複合的 1.5×。",
+    },
+    textSpacing: {
+      h2: "文字間距",
+      subtitle:
+        "文字間距工具增加字符之間的字母間距，使密集文字更容易掃描和閱讀。",
+      h3Benefits: "對讀者的好處",
+      benefitsP1:
+        "更寬的字母間距有助於閱讀障礙的使用者，他們通常反映緊密排列的字符會模糊在一起。它也有助於使用第二語言閱讀的使用者，其中個別字符識別在理解中扮演更重要的角色。",
+      benefitsP2:
+        "WCAG 2.1 成功標準 1.4.12 要求當字母間距增加到至少 0.12× 字體大小時，不得有內容損失。此工具超越了該基準。",
+      h3DenseDemo: "密集文字示範",
+      denseIntro:
+        "以下段落是刻意緊湊的。從小工具啟用文字間距，觀察字符如何散開：",
+      denseText:
+        "無障礙標準的存在是為了確保最廣泛的受眾能夠有效使用數位介面。當開發人員一致地實施這些標準時，結果是一個適用於所有人的產品——而不僅僅是多數人。",
+    },
+    screenMask: {
+      h2: "螢幕遮罩",
+      subtitle:
+        "螢幕遮罩使背景變暗，並突顯一個水平帶，當您在頁面上下移動游標時跟隨游標。",
+      h3WhoHelps: "對誰有幫助",
+      whoP1:
+        "患有注意力缺陷障礙、視覺追蹤困難或光敏感的使用者可以從隔離單一焦點線中受益。遮罩減少了閱讀時過濾周圍內容的認知負擔。",
+      whoP2:
+        "它對資訊密集的頁面也很有用——例如表格或程式碼列表——其中意外跳到錯誤行是一種常見的困擾。",
+      h3TryHere: "在這裡試試",
+      tryP1:
+        "從小工具啟用螢幕遮罩，然後緩慢地將游標向下移動此頁面。焦點帶應跟蹤您的垂直位置，使突顯區域上方和下方的所有內容變暗。",
+      tryP2:
+        "快速移動游標——帶應流暢跟隨而不滯後。然後導航到另一個頁面並返回，確認遮罩仍然有效。",
+      tryP3: "以下行間距較大，以便在焦點帶移動時更容易觀察：",
+      line1: "第一行——將游標移到這裡。",
+      line2: "第二行——現在將游標移到這裡。",
+      line3: "第三行——現在移到這裡。",
+    },
+    lineHeight: {
+      h2: "行高",
+      subtitle:
+        "行高工具增加文字行之間的垂直間距，使段落更容易從一行跟到下一行。",
+      h3WhyMatters: "為什麼間距很重要",
+      whyP1:
+        "不足的行高迫使眼睛在從一行末尾移到下一行開頭時更加努力。對於視力低下或有認知差異的使用者，這種額外的努力在長文件中累積，導致更快的疲勞。",
+      whyP2:
+        "WCAG 2.1 成功標準 1.4.12 指定最小行高為字體大小的 1.5×。許多設計未達到此基準。此工具讓使用者可以覆蓋頁面的預設間距以滿足自己的需求。",
+      h3DenseDemo: "密集段落示範",
+      denseP:
+        "此段落的行高刻意緊湊，為 1.2。從無障礙小工具啟用行高，觀察此段落展開。增加的間距應使閱讀到每行末尾而不失去位置變得明顯更容易。",
+      h3NormalPara: "正常段落",
+      normalP:
+        "此段落使用樣式表設定的預設行高。將其作為參考，比較當您調整行高設定時，上方緊湊段落相對於未修改內容的變化。",
+    },
+  },
+};

--- a/projects/demo/index.html
+++ b/projects/demo/index.html
@@ -19,10 +19,7 @@
             <h1>Astral Accessibility</h1>
           </div>
         </div>
-        <nav id="demo-nav"></nav>
-        <div class="introduction">
-          <div id="app"></div>
-        </div>
+        <div id="app-root"></div>
       </div>
     </div>
 
@@ -44,6 +41,7 @@
       import { h, render } from "https://esm.sh/preact@10";
       import { useState, useEffect } from "https://esm.sh/preact@10/hooks";
       import htm from "https://esm.sh/htm@3";
+      import { DEMO_TRANSLATIONS } from "./demo-translations.js";
 
       const html = htm.bind(h);
 
@@ -67,383 +65,260 @@
         >`;
       }
 
-      function Router() {
+      // --- Nav ---
+      function Nav({ t, language, onLanguageChange }) {
+        return html`
+          <nav>
+            <div class="nav-links">
+              <${Link} href="#/">${t.nav.home}<//>
+              <${Link} href="#/screen-reader">${t.nav.screenReader}<//>
+              <${Link} href="#/contrast">${t.nav.contrast}<//>
+              <${Link} href="#/saturation">${t.nav.saturation}<//>
+              <${Link} href="#/bigger-text">${t.nav.biggerText}<//>
+              <${Link} href="#/text-spacing">${t.nav.textSpacing}<//>
+              <${Link} href="#/screen-mask">${t.nav.screenMask}<//>
+              <${Link} href="#/line-height">${t.nav.lineHeight}<//>
+            </div>
+            <select
+              class="lang-select"
+              value=${language}
+              onChange=${(e) => onLanguageChange(e.target.value)}
+              aria-label="Select language"
+            >
+              <option value="en">English</option>
+              <option value="fr">Français</option>
+              <option value="zh-Hant">繁體中文</option>
+            </select>
+          </nav>
+        `;
+      }
+
+      // --- Pages ---
+      function HomePage({ t }) {
+        const p = t.home;
+        const nav = t.nav;
+        return html`
+          <div class="page">
+            <h2>${p.h2}</h2>
+            <p class="subtitle">${p.subtitle}</p>
+            <h3>${p.h3Features}</h3>
+            <p>${p.featuresIntro}</p>
+            <ul>
+              <li>
+                <a href="#/screen-reader">${nav.screenReader}</a> —
+                ${p.featureScreenReaderDesc}
+              </li>
+              <li>
+                <a href="#/contrast">${nav.contrast}</a> —
+                ${p.featureContrastDesc}
+              </li>
+              <li>
+                <a href="#/saturation">${nav.saturation}</a> —
+                ${p.featureSaturationDesc}
+              </li>
+              <li>
+                <a href="#/bigger-text">${nav.biggerText}</a> —
+                ${p.featureBiggerTextDesc}
+              </li>
+              <li>
+                <a href="#/text-spacing">${nav.textSpacing}</a> —
+                ${p.featureTextSpacingDesc}
+              </li>
+              <li>
+                <a href="#/screen-mask">${nav.screenMask}</a> —
+                ${p.featureScreenMaskDesc}
+              </li>
+              <li>
+                <a href="#/line-height">${nav.lineHeight}</a> —
+                ${p.featureLineHeightDesc}
+              </li>
+            </ul>
+            <h3>${p.h3About}</h3>
+            <p>${p.aboutText}</p>
+          </div>
+        `;
+      }
+
+      function ScreenReaderPage({ t }) {
+        const p = t.screenReader;
+        return html`
+          <div class="page">
+            <h2>${p.h2}</h2>
+            <p class="subtitle">${p.subtitle}</p>
+            <h3>${p.h3TryIt}</h3>
+            <p>${p.tryItP1}</p>
+            <p>${p.tryItP2}</p>
+            <h3>${p.h3AriaDemo}</h3>
+            <p>${p.ariaP}</p>
+            <button aria-label=${p.buttonAriaLabel}>${p.buttonText}</button>
+            <h3>${p.h3PlainText}</h3>
+            <p>${p.plainP1}</p>
+            <p>${p.plainP2}</p>
+          </div>
+        `;
+      }
+
+      function ContrastPage({ t }) {
+        const p = t.contrast;
+        return html`
+          <div class="page">
+            <h2>${p.h2}</h2>
+            <p class="subtitle">${p.subtitle}</p>
+            <h3>${p.h3WhyMatters}</h3>
+            <p>${p.whyP1}</p>
+            <p>${p.whyP2}</p>
+            <h3>${p.h3Enable}</h3>
+            <p>${p.enableP1}</p>
+            <p>${p.enableP2}</p>
+          </div>
+        `;
+      }
+
+      function SaturationPage({ t }) {
+        const p = t.saturation;
+        return html`
+          <div class="page">
+            <h2>${p.h2}</h2>
+            <p class="subtitle">${p.subtitle}</p>
+            <h3>${p.h3WhoBenefits}</h3>
+            <p>${p.whoP1}</p>
+            <p>${p.whoP2}</p>
+            <h3>${p.h3ColoredDemo}</h3>
+            <p style="color: #0055cc">${p.blueText}</p>
+            <p style="color: #cc4400">${p.orangeText}</p>
+            <p style="color: #007700">${p.greenText}</p>
+            <p>${p.coloredP}</p>
+          </div>
+        `;
+      }
+
+      function BiggerTextPage({ t }) {
+        const p = t.biggerText;
+        return html`
+          <div class="page">
+            <h2>${p.h2}</h2>
+            <p class="subtitle">${p.subtitle}</p>
+            <h3>${p.h3HowWorks}</h3>
+            <p>${p.howP1}</p>
+            <p>${p.howP2}</p>
+            <h3>${p.h3SampleText}</h3>
+            <p style="font-size: 12px">${p.sample12px}</p>
+            <p style="font-size: 16px">${p.sample16px}</p>
+            <p style="font-size: 20px">${p.sample20px}</p>
+            <h3>${p.h3Navigate}</h3>
+            <p>${p.navigateP}</p>
+          </div>
+        `;
+      }
+
+      function TextSpacingPage({ t }) {
+        const p = t.textSpacing;
+        return html`
+          <div class="page">
+            <h2>${p.h2}</h2>
+            <p class="subtitle">${p.subtitle}</p>
+            <h3>${p.h3Benefits}</h3>
+            <p>${p.benefitsP1}</p>
+            <p>${p.benefitsP2}</p>
+            <h3>${p.h3DenseDemo}</h3>
+            <p>${p.denseIntro}</p>
+            <p style="font-size: 0.9rem; max-width: 600px">${p.denseText}</p>
+          </div>
+        `;
+      }
+
+      function ScreenMaskPage({ t }) {
+        const p = t.screenMask;
+        return html`
+          <div class="page">
+            <h2>${p.h2}</h2>
+            <p class="subtitle">${p.subtitle}</p>
+            <h3>${p.h3WhoHelps}</h3>
+            <p>${p.whoP1}</p>
+            <p>${p.whoP2}</p>
+            <h3>${p.h3TryHere}</h3>
+            <p>${p.tryP1}</p>
+            <p>${p.tryP2}</p>
+            <p>${p.tryP3}</p>
+            <p style="margin-bottom: 2rem">${p.line1}</p>
+            <p style="margin-bottom: 2rem">${p.line2}</p>
+            <p style="margin-bottom: 2rem">${p.line3}</p>
+          </div>
+        `;
+      }
+
+      function LineHeightPage({ t }) {
+        const p = t.lineHeight;
+        return html`
+          <div class="page">
+            <h2>${p.h2}</h2>
+            <p class="subtitle">${p.subtitle}</p>
+            <h3>${p.h3WhyMatters}</h3>
+            <p>${p.whyP1}</p>
+            <p>${p.whyP2}</p>
+            <h3>${p.h3DenseDemo}</h3>
+            <p style="line-height: 1.2; max-width: 620px">${p.denseP}</p>
+            <h3>${p.h3NormalPara}</h3>
+            <p>${p.normalP}</p>
+          </div>
+        `;
+      }
+
+      // --- Router ---
+      function Router({ route, t }) {
+        switch (route) {
+          case "screen-reader":
+            return html`<${ScreenReaderPage} t=${t} />`;
+          case "contrast":
+            return html`<${ContrastPage} t=${t} />`;
+          case "saturation":
+            return html`<${SaturationPage} t=${t} />`;
+          case "bigger-text":
+            return html`<${BiggerTextPage} t=${t} />`;
+          case "text-spacing":
+            return html`<${TextSpacingPage} t=${t} />`;
+          case "screen-mask":
+            return html`<${ScreenMaskPage} t=${t} />`;
+          case "line-height":
+            return html`<${LineHeightPage} t=${t} />`;
+          default:
+            return html`<${HomePage} t=${t} />`;
+        }
+      }
+
+      // --- App root ---
+      function App() {
+        const [language, setLanguage] = useState("en");
         const [route, setRoute] = useState(getRoute());
+
         useEffect(() => {
           const onHash = () => setRoute(getRoute());
           window.addEventListener("hashchange", onHash);
           return () => window.removeEventListener("hashchange", onHash);
         }, []);
 
-        switch (route) {
-          case "screen-reader":
-            return html`<${ScreenReaderPage} />`;
-          case "contrast":
-            return html`<${ContrastPage} />`;
-          case "saturation":
-            return html`<${SaturationPage} />`;
-          case "bigger-text":
-            return html`<${BiggerTextPage} />`;
-          case "text-spacing":
-            return html`<${TextSpacingPage} />`;
-          case "screen-mask":
-            return html`<${ScreenMaskPage} />`;
-          case "line-height":
-            return html`<${LineHeightPage} />`;
-          default:
-            return html`<${HomePage} />`;
+        const t = DEMO_TRANSLATIONS[language];
+
+        function handleLanguageChange(lang) {
+          setLanguage(lang);
+          document.documentElement.lang = lang;
+          if (window.astralSetLanguage) window.astralSetLanguage(lang);
         }
-      }
 
-      // --- Pages ---
-
-      function HomePage() {
         return html`
-          <div class="page">
-            <h2>Welcome</h2>
-            <p class="subtitle">
-              Astral Accessibility is a widget that provides reading and visual
-              accessibility tools for web applications. Use the button in the
-              bottom-right corner to open the panel and try each feature.
-            </p>
-            <h3>Features</h3>
-            <p>
-              Navigate to each feature page to see the tool in action on a
-              dedicated page.
-            </p>
-            <ul>
-              <li>
-                <a href="#/screen-reader">Screen Reader</a> — reads out text
-                when you click on elements
-              </li>
-              <li>
-                <a href="#/contrast">Contrast</a> — high-contrast and dark modes
-                for better legibility
-              </li>
-              <li>
-                <a href="#/saturation">Saturation</a> — adjust colour saturation
-                or switch to greyscale
-              </li>
-              <li>
-                <a href="#/bigger-text">Bigger Text</a> — scale text up to
-                Medium, Large, or Extra Large
-              </li>
-              <li>
-                <a href="#/text-spacing">Text Spacing</a> — increase letter
-                spacing for readability
-              </li>
-              <li>
-                <a href="#/screen-mask">Screen Mask</a> — dim the screen with a
-                focus band that follows your cursor
-              </li>
-              <li>
-                <a href="#/line-height">Line Height</a> — increase vertical
-                spacing between lines
-              </li>
-            </ul>
-            <h3>About this demo</h3>
-            <p>
-              Each page contains text so you can observe how the accessibility
-              tools affect real content. Enable a setting, then navigate between
-              pages to confirm the setting persists.
-            </p>
+          <${Nav}
+            t=${t}
+            language=${language}
+            onLanguageChange=${handleLanguageChange}
+          />
+          <div class="introduction">
+            <${Router} route=${route} t=${t} />
           </div>
-        `;
-      }
-
-      function ScreenReaderPage() {
-        return html`
-          <div class="page">
-            <h2>Screen Reader</h2>
-            <p class="subtitle">
-              The screen reader reads out content when you click on any element.
-              If an <code>aria-label</code> is present it uses that; otherwise
-              it reads the element's visible text. Three speeds are available:
-              normal, fast, and slow.
-            </p>
-            <h3>Try it</h3>
-            <p>
-              Enable the Screen Reader from the widget, then click anywhere on
-              this page. Headings, paragraphs, links, and labelled inputs should
-              all be read aloud.
-            </p>
-            <p>
-              Assistive technology benefits users with low vision, dyslexia, and
-              attention difficulties. By hearing content read back, users can
-              confirm what they are interacting with without needing to read
-              every word on screen.
-            </p>
-            <h3>Aria label demo</h3>
-            <p>
-              The button below has an <code>aria-label</code> that differs from
-              its visible text. The screen reader should speak the label, not
-              the text.
-            </p>
-            <button aria-label="Submit the registration form">Sign up</button>
-            <h3>Plain text demo</h3>
-            <p>
-              This paragraph has no special markup. Clicking it should read the
-              raw text content aloud at the currently selected speed.
-            </p>
-            <p>
-              Accessibility is not a feature — it is a quality. Building
-              inclusive interfaces ensures that every user, regardless of
-              ability, can engage with digital content on equal footing.
-            </p>
-          </div>
-        `;
-      }
-
-      function ContrastPage() {
-        return html`
-          <div class="page">
-            <h2>Contrast</h2>
-            <p class="subtitle">
-              The contrast tool modifies background and foreground colours to
-              increase the difference between text and its surroundings. Three
-              modes are available: invert colours, high contrast, and dark high
-              contrast.
-            </p>
-            <h3>Why contrast matters</h3>
-            <p>
-              Low contrast between text and background is one of the most common
-              barriers for users with low vision or colour blindness. WCAG 2.1
-              requires a contrast ratio of at least 4.5:1 for normal text and
-              3:1 for large text.
-            </p>
-            <p>
-              High-contrast modes benefit users in bright environments too —
-              sunlight reflecting off a screen can reduce effective contrast
-              significantly.
-            </p>
-            <h3>Enable and compare</h3>
-            <p>
-              Open the accessibility widget and cycle through the contrast
-              options. Observe how the background and text colours change on
-              this page and in the navigation bar above.
-            </p>
-            <p>
-              After switching modes, navigate to another feature page and back
-              to confirm the contrast setting is preserved across navigation.
-            </p>
-          </div>
-        `;
-      }
-
-      function SaturationPage() {
-        return html`
-          <div class="page">
-            <h2>Saturation</h2>
-            <p class="subtitle">
-              The saturation tool adjusts how vivid the colours appear on
-              screen. Three modes let you lower saturation, increase it, or
-              remove colour entirely for a greyscale view.
-            </p>
-            <h3>Who benefits</h3>
-            <p>
-              Users with colour vision deficiency may find reduced or altered
-              saturation easier to distinguish. Greyscale mode removes colour as
-              a carrier of meaning entirely, which is useful for testing whether
-              a design is accessible without relying on colour alone.
-            </p>
-            <p>
-              Oversaturation can be useful for users with certain visual
-              processing differences who perceive low-saturation displays as
-              washed out.
-            </p>
-            <h3>Coloured content demo</h3>
-            <p style="color: #0055cc">This sentence is rendered in blue.</p>
-            <p style="color: #cc4400">
-              This sentence is rendered in orange-red.
-            </p>
-            <p style="color: #007700">This sentence is rendered in green.</p>
-            <p>
-              Cycle through the saturation settings from the widget and observe
-              how the coloured sentences above change. Greyscale mode should
-              render all three paragraphs in similar shades of grey.
-            </p>
-          </div>
-        `;
-      }
-
-      function BiggerTextPage() {
-        return html`
-          <div class="page">
-            <h2>Bigger Text</h2>
-            <p class="subtitle">
-              The Bigger Text tool scales all text on the page. Three levels are
-              available: Medium (1.2×), Large (1.5×), and Extra Large (1.8×).
-            </p>
-            <h3>How it works</h3>
-            <p>
-              Text scaling is applied by traversing the DOM and adjusting the
-              computed font size of each text-bearing element. A
-              MutationObserver watches for new nodes added during navigation so
-              that dynamically rendered content is scaled too.
-            </p>
-            <p>
-              Enable a text size level, then navigate to another page and back.
-              The font should remain at the selected size without growing larger
-              on each navigation.
-            </p>
-            <h3>Sample text at various sizes</h3>
-            <p style="font-size: 12px">
-              This paragraph uses a 12px base font size.
-            </p>
-            <p style="font-size: 16px">
-              This paragraph uses a 16px base font size.
-            </p>
-            <p style="font-size: 20px">
-              This paragraph uses a 20px base font size.
-            </p>
-            <h3>Navigate and return</h3>
-            <p>
-              Set the text size to Large, navigate to the Screen Reader page,
-              then return here. The paragraph sizes above should be exactly 1.5×
-              their original values — not 1.5× compounded over multiple
-              navigations.
-            </p>
-          </div>
-        `;
-      }
-
-      function TextSpacingPage() {
-        return html`
-          <div class="page">
-            <h2>Text Spacing</h2>
-            <p class="subtitle">
-              The Text Spacing tool increases the letter spacing between
-              characters, making dense text easier to scan and read.
-            </p>
-            <h3>Benefits for readers</h3>
-            <p>
-              Wider letter spacing benefits users with dyslexia, who often
-              report that tightly packed characters blur together. It also helps
-              users reading in a second language, where individual character
-              recognition plays a larger role in comprehension.
-            </p>
-            <p>
-              WCAG 2.1 Success Criterion 1.4.12 requires that no loss of content
-              occurs when letter spacing is increased to at least 0.12× the font
-              size. This tool goes beyond that baseline.
-            </p>
-            <h3>Dense text demo</h3>
-            <p>
-              The following paragraph is intentionally compact. Enable Text
-              Spacing from the widget and observe how the characters spread
-              apart:
-            </p>
-            <p style="font-size: 0.9rem; max-width: 600px">
-              Accessibility standards exist to ensure that the broadest possible
-              audience can use digital interfaces effectively. When developers
-              implement these standards consistently, the result is a product
-              that works for everyone — not just the majority.
-            </p>
-          </div>
-        `;
-      }
-
-      function ScreenMaskPage() {
-        return html`
-          <div class="page">
-            <h2>Screen Mask</h2>
-            <p class="subtitle">
-              The Screen Mask dims the background and highlights a horizontal
-              band that follows your cursor as you move it up and down the page.
-            </p>
-            <h3>Who it helps</h3>
-            <p>
-              Users with attention deficit disorders, visual tracking
-              difficulties, or photosensitivity benefit from isolating a single
-              line of focus. The mask reduces the cognitive load of filtering
-              out surrounding content while reading.
-            </p>
-            <p>
-              It is also useful on information-dense pages — such as tables or
-              code listings — where accidentally jumping to the wrong row is a
-              common frustration.
-            </p>
-            <h3>Try it here</h3>
-            <p>
-              Enable the Screen Mask from the widget, then move your cursor
-              slowly down this page. The focus band should track your vertical
-              position, dimming everything above and below the highlighted area.
-            </p>
-            <p>
-              Move your cursor quickly — the band should follow smoothly without
-              lag. Then navigate to another page and back to confirm the mask
-              remains active.
-            </p>
-            <p>
-              The following lines are spaced generously to make the focus band
-              easier to observe as it moves:
-            </p>
-            <p style="margin-bottom: 2rem">Line one — move your cursor here.</p>
-            <p style="margin-bottom: 2rem">
-              Line two — now move your cursor here.
-            </p>
-            <p style="margin-bottom: 2rem">Line three — and now here.</p>
-          </div>
-        `;
-      }
-
-      function LineHeightPage() {
-        return html`
-          <div class="page">
-            <h2>Line Height</h2>
-            <p class="subtitle">
-              The Line Height tool increases the vertical spacing between lines
-              of text, making paragraphs easier to follow from one line to the
-              next.
-            </p>
-            <h3>Why spacing matters</h3>
-            <p>
-              Insufficient line height forces the eye to work harder when moving
-              from the end of one line to the beginning of the next. For users
-              with low vision or cognitive differences, this extra effort
-              accumulates across a long document and leads to faster fatigue.
-            </p>
-            <p>
-              WCAG 2.1 Success Criterion 1.4.12 specifies a minimum line height
-              of 1.5× the font size. Many designs fall short of this baseline.
-              This tool lets users override the page's default spacing to meet
-              their own needs.
-            </p>
-            <h3>Dense paragraph demo</h3>
-            <p style="line-height: 1.2; max-width: 620px">
-              This paragraph has a deliberately tight line height of 1.2. Enable
-              Line Height from the accessibility widget and watch this paragraph
-              open up. The increased spacing should make it noticeably easier to
-              read through to the end of each line without losing your place.
-            </p>
-            <h3>Normal paragraph</h3>
-            <p>
-              This paragraph uses the default line height set by the stylesheet.
-              Use it as a reference to compare how the tight paragraph above
-              changes relative to unmodified content when you adjust the line
-              height setting.
-            </p>
-          </div>
-        `;
-      }
-
-      // --- Nav ---
-      function Nav() {
-        return html`
-          <${Link} href="#/">Home<//>
-          <${Link} href="#/screen-reader">Screen Reader<//>
-          <${Link} href="#/contrast">Contrast<//>
-          <${Link} href="#/saturation">Saturation<//>
-          <${Link} href="#/bigger-text">Bigger Text<//>
-          <${Link} href="#/text-spacing">Text Spacing<//>
-          <${Link} href="#/screen-mask">Screen Mask<//>
-          <${Link} href="#/line-height">Line Height<//>
         `;
       }
 
       // --- Mount ---
-      render(html`<${Nav} />`, document.getElementById("demo-nav"));
-      render(html`<${Router} />`, document.getElementById("app"));
+      render(html`<${App} />`, document.getElementById("app-root"));
     </script>
   </body>
 </html>

--- a/projects/demo/styles.css
+++ b/projects/demo/styles.css
@@ -210,6 +210,36 @@ nav {
   display: flex;
   flex-wrap: wrap;
   gap: 0;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.nav-links {
+  display: flex;
+  flex-wrap: wrap;
+}
+
+.lang-select {
+  background: transparent;
+  color: #ccc;
+  border: 1px solid #555;
+  border-radius: 4px;
+  padding: 0.3rem 0.5rem;
+  font-family: "Poppins", sans-serif;
+  font-size: 0.8rem;
+  cursor: pointer;
+  margin-left: 0.5rem;
+  flex-shrink: 0;
+}
+
+.lang-select:focus {
+  outline: 2px solid #ffd73b;
+  outline-offset: 2px;
+}
+
+.lang-select option {
+  background: #1a1a2e;
+  color: #ccc;
 }
 
 nav a {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,7 @@
 {
   "compileOnSave": false,
   "compilerOptions": {
+    "resolveJsonModule": true,
     "paths": {
       "astral-accessibility": ["dist/astral-accessibility"]
     },
@@ -23,7 +24,8 @@
     "importHelpers": true,
     "target": "es2020",
     "module": "es2020",
-    "lib": ["es2020", "dom"]
+    "allowSyntheticDefaultImports": true,
+    "lib": ["es2020", "dom", "dom.iterable"]
   },
   "angularCompilerOptions": {
     "enableI18nLegacyMessageIdFormat": false,


### PR DESCRIPTION
## Summary

Resolves #67

- Adds a `language` key to the `astral-features` JSON attribute so consumers can set the widget's display language (`"fr"` for French, `"zh-Hant"` for Traditional Chinese, defaults to English)
- Introduces `AstralTranslationService` — a singleton that statically imports all three locale JSON files and exposes `setLanguage(lang)` and `t(key)` for zero-cost locale switching
- Updates all 7 control components with a `labels` getter for translated display text; internal state logic (state arrays, `_runStateLogic`, `[ngClass]`) remains English-only and unchanged

## Usage

```json
{
  "enabledFeatures": ["Screen Reader", "Contrast", "Bigger Text"],
  "language": "fr"
}
```

## Test Plan

- [x] Run `ng test astral-accessibility --watch=false` — 28 specs, 0 failures
- [x] Load the demo with `"language": "fr"` in `initializeAstral` options and confirm all widget labels render in French
- [x] Load the demo with `"language": "zh-Hant"` and confirm Traditional Chinese labels
- [x] Load the demo with no `language` key and confirm English is the default
- [x] Confirm cycling through states (e.g. Contrast → Invert → High Contrast) still works correctly in all languages

🤖 Generated with [Claude Code](https://claude.com/claude-code)