### PR TITLE
feat: configurable widget position

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,36 @@ Optionally we can choose which widgets should appear by passing an object inside
 </script>
 ```
 
+### Configuring Widget Position
+
+By default the widget appears in the bottom-right corner of the screen. You can change this by passing a `position` option to `initializeAstral`.
+
+Supported values:
+
+| Value          | Description                       |
+| -------------- | --------------------------------- |
+| `bottom-right` | Bottom-right corner **(default)** |
+| `bottom-left`  | Bottom-left corner                |
+| `top-right`    | Top-right corner                  |
+| `top-left`     | Top-left corner                   |
+
+```html
+<script>
+  initializeAstral({
+    position: "bottom-left",
+    enabledFeatures: [
+      "Screen Reader",
+      "Contrast",
+      "Saturation",
+      "Bigger Text",
+      "Text Spacing",
+      "Screen Mask",
+      "Line Height",
+    ],
+  });
+</script>
+```
+
 ## Language Support
 
 Astral supports multiple languages for the widget UI labels and text-to-speech voice selection. The built-in languages are:

--- a/projects/astral-accessibility/src/lib/astral-accessibility.component.html
+++ b/projects/astral-accessibility/src/lib/astral-accessibility.component.html
@@ -2,7 +2,12 @@
   name="viewport"
   content="width=device-width, initial-scale=1, minimum-scale=1"
 />
-<div class="astral-accessibility d-flex align-items-end">
+<div
+  [class]="
+    'astral-accessibility d-flex ' +
+    (isTopPosition ? 'align-items-start' : 'align-items-end')
+  "
+>
   <div>
     <div class="astral-inverted-corner"></div>
     <button

--- a/projects/astral-accessibility/src/lib/astral-accessibility.component.scss
+++ b/projects/astral-accessibility/src/lib/astral-accessibility.component.scss
@@ -5,8 +5,6 @@
   flex-direction: column;
   position: fixed;
   z-index: 999999;
-  bottom: 43px;
-  right: 0px;
   transition: max-width 0.1s ease-in-out;
 
   --iconWidth: 70px;
@@ -28,6 +26,44 @@
   --pageWdith: 100%;
   --pageHeight: 100%;
   --pageBackgroundColor: #fff;
+}
+
+:host(.astral-position-bottom-right) {
+  bottom: 43px;
+  right: 0px;
+}
+
+:host(.astral-position-bottom-left) {
+  bottom: 43px;
+  left: 0px;
+}
+
+:host(.astral-position-top-right) {
+  top: 43px;
+  right: 0px;
+}
+
+:host(.astral-position-top-left) {
+  top: 43px;
+  left: 0px;
+}
+
+:host(.astral-position-bottom-left),
+:host(.astral-position-top-left) {
+  .astral-icon {
+    border-radius: 0 20px 20px 0;
+    padding-right: 8px;
+    padding-left: 16px;
+    margin-right: 0;
+    margin-left: -4px;
+  }
+
+  .astral-modal {
+    margin-right: 0;
+    margin-left: -8px;
+    padding-right: 10px;
+    padding-left: 18px;
+  }
 }
 
 .astral-position {

--- a/projects/astral-accessibility/src/lib/astral-accessibility.component.spec.ts
+++ b/projects/astral-accessibility/src/lib/astral-accessibility.component.spec.ts
@@ -3,22 +3,164 @@ import { ComponentFixture, TestBed } from "@angular/core/testing";
 import { AstralAccessibilityComponent } from "./astral-accessibility.component";
 import { AstralTranslationService } from "./astral-translation.service";
 
-describe("AstralAccessibilityComponent", () => {
-  let component: AstralAccessibilityComponent;
-  let fixture: ComponentFixture<AstralAccessibilityComponent>;
+const ALL_POSITIONS = [
+  "bottom-right",
+  "bottom-left",
+  "top-right",
+  "top-left",
+] as const;
 
-  beforeEach(async () => {
+describe("AstralAccessibilityComponent", () => {
+  async function configure() {
     await TestBed.configureTestingModule({
       imports: [AstralAccessibilityComponent],
       providers: [AstralTranslationService],
     }).compileComponents();
+  }
 
-    fixture = TestBed.createComponent(AstralAccessibilityComponent);
-    component = fixture.componentInstance;
-    fixture.detectChanges();
+  describe("default state", () => {
+    let component: AstralAccessibilityComponent;
+    let fixture: ComponentFixture<AstralAccessibilityComponent>;
+
+    beforeEach(async () => {
+      await configure();
+      fixture = TestBed.createComponent(AstralAccessibilityComponent);
+      component = fixture.componentInstance;
+      fixture.detectChanges();
+    });
+
+    it("should create", () => {
+      expect(component).toBeTruthy();
+    });
+
+    it("defaults position to bottom-right", () => {
+      expect(component.position).toBe("bottom-right");
+    });
+
+    it("hostClass is astral-position-bottom-right by default", () => {
+      expect(component.hostClass).toBe("astral-position-bottom-right");
+    });
+
+    it("isTopPosition is false by default", () => {
+      expect(component.isTopPosition).toBeFalse();
+    });
   });
 
-  it("should create", () => {
-    expect(component).toBeTruthy();
+  describe("position getters", () => {
+    let component: AstralAccessibilityComponent;
+    let fixture: ComponentFixture<AstralAccessibilityComponent>;
+
+    beforeEach(async () => {
+      await configure();
+      fixture = TestBed.createComponent(AstralAccessibilityComponent);
+      component = fixture.componentInstance;
+      fixture.detectChanges();
+    });
+
+    ALL_POSITIONS.forEach((pos) => {
+      it(`hostClass returns astral-position-${pos}`, () => {
+        component.position = pos;
+        expect(component.hostClass).toBe(`astral-position-${pos}`);
+      });
+    });
+
+    it("isTopPosition is false for bottom-right", () => {
+      component.position = "bottom-right";
+      expect(component.isTopPosition).toBeFalse();
+    });
+
+    it("isTopPosition is false for bottom-left", () => {
+      component.position = "bottom-left";
+      expect(component.isTopPosition).toBeFalse();
+    });
+
+    it("isTopPosition is true for top-right", () => {
+      component.position = "top-right";
+      expect(component.isTopPosition).toBeTrue();
+    });
+
+    it("isTopPosition is true for top-left", () => {
+      component.position = "top-left";
+      expect(component.isTopPosition).toBeTrue();
+    });
+  });
+
+  describe("position from astral-features attribute", () => {
+    function createWithOptions(options: Record<string, unknown>) {
+      const merged = { enabledFeatures: [], ...options };
+      const original = document.querySelector.bind(document);
+      spyOn(document, "querySelector").and.callFake((selector: string) => {
+        if (selector === "astral-accessibility") {
+          return {
+            getAttribute: (_attr: string) => JSON.stringify(merged),
+          } as unknown as Element;
+        }
+        return original(selector);
+      });
+
+      const fixture = TestBed.createComponent(AstralAccessibilityComponent);
+      fixture.detectChanges();
+      return fixture.componentInstance;
+    }
+
+    beforeEach(async () => {
+      await configure();
+    });
+
+    ALL_POSITIONS.forEach((pos) => {
+      it(`reads position "${pos}" from attribute`, () => {
+        const component = createWithOptions({ position: pos });
+        expect(component.position).toBe(pos);
+      });
+    });
+
+    it("falls back to bottom-right when position is omitted", () => {
+      const component = createWithOptions({ enabledFeatures: [] });
+      expect(component.position).toBe("bottom-right");
+    });
+  });
+
+  describe("template alignment class", () => {
+    let component: AstralAccessibilityComponent;
+    let fixture: ComponentFixture<AstralAccessibilityComponent>;
+
+    beforeEach(async () => {
+      await configure();
+      fixture = TestBed.createComponent(AstralAccessibilityComponent);
+      component = fixture.componentInstance;
+      fixture.detectChanges();
+    });
+
+    it("uses align-items-end for bottom-right", () => {
+      component.position = "bottom-right";
+      fixture.detectChanges();
+      const el = fixture.nativeElement.querySelector(".astral-accessibility");
+      expect(el.classList).toContain("align-items-end");
+      expect(el.classList).not.toContain("align-items-start");
+    });
+
+    it("uses align-items-end for bottom-left", () => {
+      component.position = "bottom-left";
+      fixture.detectChanges();
+      const el = fixture.nativeElement.querySelector(".astral-accessibility");
+      expect(el.classList).toContain("align-items-end");
+      expect(el.classList).not.toContain("align-items-start");
+    });
+
+    it("uses align-items-start for top-right", () => {
+      component.position = "top-right";
+      fixture.detectChanges();
+      const el = fixture.nativeElement.querySelector(".astral-accessibility");
+      expect(el.classList).toContain("align-items-start");
+      expect(el.classList).not.toContain("align-items-end");
+    });
+
+    it("uses align-items-start for top-left", () => {
+      component.position = "top-left";
+      fixture.detectChanges();
+      const el = fixture.nativeElement.querySelector(".astral-accessibility");
+      expect(el.classList).toContain("align-items-start");
+      expect(el.classList).not.toContain("align-items-end");
+    });
   });
 });

--- a/projects/astral-accessibility/src/lib/astral-accessibility.component.ts
+++ b/projects/astral-accessibility/src/lib/astral-accessibility.component.ts
@@ -1,5 +1,5 @@
 import { NgIf } from "@angular/common";
-import { Component, CUSTOM_ELEMENTS_SCHEMA } from "@angular/core";
+import { Component, CUSTOM_ELEMENTS_SCHEMA, HostBinding } from "@angular/core";
 import { ContrastComponent } from "./controls/contrast.component";
 import { InvertComponent } from "./controls/invert.component";
 import { SaturateComponent } from "./controls/saturate.component";
@@ -9,6 +9,12 @@ import { ScreenReaderComponent } from "./controls/screen-reader.component";
 import { ScreenMaskComponent } from "./controls/screen-mask.component";
 import { LineHeightComponent } from "./controls/line-height.component";
 import { AstralTranslationService } from "./astral-translation.service";
+
+export type AstralPosition =
+  | "bottom-right"
+  | "bottom-left"
+  | "top-right"
+  | "top-left";
 
 @Component({
   selector: "astral-accessibility",
@@ -35,6 +41,16 @@ export class AstralAccessibilityComponent {
   astralAccessibilityIcon = "astral-icon";
   options: Record<string, any> = {};
   enabledFeatures: String[] = [];
+  position: AstralPosition = "bottom-right";
+
+  @HostBinding("class")
+  get hostClass(): string {
+    return `astral-position-${this.position}`;
+  }
+
+  get isTopPosition(): boolean {
+    return this.position.startsWith("top");
+  }
 
   constructor(private translationService: AstralTranslationService) {}
 
@@ -45,6 +61,8 @@ export class AstralAccessibilityComponent {
     if (astralOptions) {
       this.options = JSON.parse(astralOptions);
       this.enabledFeatures = this.options["enabledFeatures"];
+      this.position =
+        (this.options["position"] as AstralPosition) || "bottom-right";
       if (this.options["language"]) {
         this.translationService.setLanguage(this.options["language"]);
       }


### PR DESCRIPTION
## Summary

- Adds a `position` option to `initializeAstral` supporting `bottom-right` (default), `bottom-left`, `top-right`, and `top-left`
- Applies host CSS classes (`astral-position-{position}`) for fixed positioning so each corner is independently styled
- Flips the icon button border-radius and padding for left-side placements so the tab appearance faces the correct edge
- Switches modal panel margin/padding for left-side placements
- For top positions, swaps Bootstrap `align-items-end` → `align-items-start` so the icon aligns at the top and the panel extends downward
- Updates README with a supported-values table and usage example

Closes #56

## Usage

```html
<script src="https://astral-cdn.vertolink.com/latest/main.js"></script>
<script>
  initializeAstral({
    position: "bottom-left", // "bottom-right" | "bottom-left" | "top-right" | "top-left"
    enabledFeatures: ["Contrast", "Bigger Text"],
  });
</script>
```

## Test plan

- [ ] Widget renders in bottom-right by default (no `position` option)
- [ ] Widget renders in bottom-left when `position: "bottom-left"` — tab faces right edge of button
- [ ] Widget renders in top-right when `position: "top-right"` — panel extends downward
- [ ] Widget renders in top-left when `position: "top-left"` — panel extends downward, tab faces right
- [ ] Omitting `position` from options falls back to `bottom-right`

🤖 Generated with [Claude Code](https://claude.com/claude-code)