### PR TITLE
feat: allow brand color customization for toggle button

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ If your brand color is dark, set `toggleIconColor` to `#ffffff` so the icon rema
 ```
 
 > **Accessibility note:** Ensure your chosen `toggleColor` provides sufficient contrast with `toggleIconColor` (default `#000000`). WCAG AA requires a contrast ratio of at least 3:1 for graphical elements.
+
 ## Language Support
 
 Astral supports multiple languages for the widget UI labels and text-to-speech voice selection. The built-in languages are:

--- a/README.md
+++ b/README.md
@@ -127,6 +127,30 @@ Supported values:
 </script>
 ```
 
+### Customizing Toggle Button Color
+
+You can customize the background color of the toggle button to match your website's branding by passing `toggleColor` to `initializeAstral`. Any valid CSS color value is accepted (hex, RGB, named colors, etc.).
+
+```html
+<script>
+  initializeAstral({
+    toggleColor: "#0057b8",
+  });
+</script>
+```
+
+If your brand color is dark, set `toggleIconColor` to `#ffffff` so the icon remains visible:
+
+```html
+<script>
+  initializeAstral({
+    toggleColor: "#0057b8",
+    toggleIconColor: "#ffffff",
+  });
+</script>
+```
+
+> **Accessibility note:** Ensure your chosen `toggleColor` provides sufficient contrast with `toggleIconColor` (default `#000000`). WCAG AA requires a contrast ratio of at least 3:1 for graphical elements.
 ## Language Support
 
 Astral supports multiple languages for the widget UI labels and text-to-speech voice selection. The built-in languages are:

--- a/projects/astral-accessibility/src/lib/astral-accessibility.component.scss
+++ b/projects/astral-accessibility/src/lib/astral-accessibility.component.scss
@@ -22,6 +22,8 @@
   --actionIconActiveBackgroundColor: #ffd73b;
   --actionIconInactiveBackgroundColor: #6c6c6c;
   --actionIconDisabledBackgroundColor: #595959;
+  --toggleButtonColor: var(--actionActiveBackgroundColor);
+  --toggleIconColor: #000000;
 
   --pageWdith: 100%;
   --pageHeight: 100%;
@@ -99,11 +101,15 @@
   width: var(--iconWidth);
 
   svg {
-    background: var(--actionActiveBackgroundColor);
+    background: var(--toggleButtonColor);
     border-radius: 50%;
     width: 55px;
     height: 55px;
     padding: 11px;
+
+    path {
+      fill: var(--toggleIconColor);
+    }
   }
 }
 
@@ -116,10 +122,14 @@
 .astral-icon-mobile {
   padding: 6px;
   svg {
-    background: var(--actionActiveBackgroundColor);
+    background: var(--toggleButtonColor);
     border-radius: 50%;
     width: 49px;
     height: 49px;
+
+    path {
+      fill: var(--toggleIconColor);
+    }
   }
 }
 

--- a/projects/astral-accessibility/src/lib/astral-accessibility.component.spec.ts
+++ b/projects/astral-accessibility/src/lib/astral-accessibility.component.spec.ts
@@ -120,6 +120,70 @@ describe("AstralAccessibilityComponent", () => {
     });
   });
 
+  describe("toggle button color from astral-features attribute", () => {
+    function createWithOptions(options: Record<string, unknown>) {
+      const merged = { enabledFeatures: [], ...options };
+      const original = document.querySelector.bind(document);
+      spyOn(document, "querySelector").and.callFake((selector: string) => {
+        if (selector === "astral-accessibility") {
+          return {
+            getAttribute: (_attr: string) => JSON.stringify(merged),
+          } as unknown as Element;
+        }
+        return original(selector);
+      });
+
+      const fixture = TestBed.createComponent(AstralAccessibilityComponent);
+      fixture.detectChanges();
+      return fixture;
+    }
+
+    beforeEach(async () => {
+      await configure();
+    });
+
+    it("sets --toggleButtonColor when toggleColor is provided", () => {
+      const fixture = createWithOptions({ toggleColor: "#0057b8" });
+      expect(
+        fixture.nativeElement.style.getPropertyValue("--toggleButtonColor"),
+      ).toBe("#0057b8");
+    });
+
+    it("sets --toggleIconColor when toggleIconColor is provided", () => {
+      const fixture = createWithOptions({ toggleIconColor: "#ffffff" });
+      expect(
+        fixture.nativeElement.style.getPropertyValue("--toggleIconColor"),
+      ).toBe("#ffffff");
+    });
+
+    it("sets both CSS variables when both options are provided", () => {
+      const fixture = createWithOptions({
+        toggleColor: "#0057b8",
+        toggleIconColor: "#ffffff",
+      });
+      expect(
+        fixture.nativeElement.style.getPropertyValue("--toggleButtonColor"),
+      ).toBe("#0057b8");
+      expect(
+        fixture.nativeElement.style.getPropertyValue("--toggleIconColor"),
+      ).toBe("#ffffff");
+    });
+
+    it("does not set --toggleButtonColor when toggleColor is omitted", () => {
+      const fixture = createWithOptions({});
+      expect(
+        fixture.nativeElement.style.getPropertyValue("--toggleButtonColor"),
+      ).toBe("");
+    });
+
+    it("does not set --toggleIconColor when toggleIconColor is omitted", () => {
+      const fixture = createWithOptions({});
+      expect(
+        fixture.nativeElement.style.getPropertyValue("--toggleIconColor"),
+      ).toBe("");
+    });
+  });
+
   describe("template alignment class", () => {
     let component: AstralAccessibilityComponent;
     let fixture: ComponentFixture<AstralAccessibilityComponent>;

--- a/projects/astral-accessibility/src/lib/astral-accessibility.component.ts
+++ b/projects/astral-accessibility/src/lib/astral-accessibility.component.ts
@@ -1,5 +1,10 @@
 import { NgIf } from "@angular/common";
-import { Component, CUSTOM_ELEMENTS_SCHEMA, ElementRef, HostBinding } from "@angular/core";
+import {
+  Component,
+  CUSTOM_ELEMENTS_SCHEMA,
+  ElementRef,
+  HostBinding,
+} from "@angular/core";
 import { ContrastComponent } from "./controls/contrast.component";
 import { InvertComponent } from "./controls/invert.component";
 import { SaturateComponent } from "./controls/saturate.component";

--- a/projects/astral-accessibility/src/lib/astral-accessibility.component.ts
+++ b/projects/astral-accessibility/src/lib/astral-accessibility.component.ts
@@ -1,5 +1,5 @@
 import { NgIf } from "@angular/common";
-import { Component, CUSTOM_ELEMENTS_SCHEMA, HostBinding } from "@angular/core";
+import { Component, CUSTOM_ELEMENTS_SCHEMA, ElementRef, HostBinding } from "@angular/core";
 import { ContrastComponent } from "./controls/contrast.component";
 import { InvertComponent } from "./controls/invert.component";
 import { SaturateComponent } from "./controls/saturate.component";
@@ -52,7 +52,10 @@ export class AstralAccessibilityComponent {
     return this.position.startsWith("top");
   }
 
-  constructor(private translationService: AstralTranslationService) {}
+  constructor(
+    private translationService: AstralTranslationService,
+    private elementRef: ElementRef,
+  ) {}
 
   ngOnInit() {
     const astralElement = document.querySelector("astral-accessibility");
@@ -65,6 +68,20 @@ export class AstralAccessibilityComponent {
         (this.options["position"] as AstralPosition) || "bottom-right";
       if (this.options["language"]) {
         this.translationService.setLanguage(this.options["language"]);
+      }
+
+      if (this.options["toggleColor"]) {
+        this.elementRef.nativeElement.style.setProperty(
+          "--toggleButtonColor",
+          this.options["toggleColor"],
+        );
+      }
+
+      if (this.options["toggleIconColor"]) {
+        this.elementRef.nativeElement.style.setProperty(
+          "--toggleIconColor",
+          this.options["toggleIconColor"],
+        );
       }
     }
 


### PR DESCRIPTION
## Summary

- Adds `toggleColor` option to `initializeAstral()` to set a custom background color for the toggle button
- Adds `toggleIconColor` option to control the icon fill color (defaults to `#000000`) for contrast against dark brand colors
- Introduces `--toggleButtonColor` and `--toggleIconColor` CSS variables (separate from `--actionActiveBackgroundColor` so action buttons are unaffected)
- Updates README with usage examples and an accessibility contrast note

Closes #57

## Usage

```html
<script>
  initializeAstral({
    toggleColor: "#0057b8",
    toggleIconColor: "#ffffff",
  });
</script>
```

## Test plan

- [ ] Set `toggleColor` to a custom hex color and confirm the toggle button background changes
- [ ] Set `toggleIconColor: "#ffffff"` with a dark `toggleColor` and confirm the icon is visible
- [ ] Omit both options and confirm default yellow/black appearance is unchanged
- [ ] Test on mobile to confirm `.astral-icon-mobile` also picks up the custom color

🤖 Generated with [Claude Code](https://claude.com/claude-code)