### PR TITLE
ci: bump deprecated github action versions

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -13,8 +13,8 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
         with:
           node-version: "24"
           cache: "yarn"
@@ -22,7 +22,7 @@ jobs:
         run: |
           yarn install
       - name: Run Cypress for environment
-        uses: cypress-io/github-action@v2
+        uses: cypress-io/github-action@v6
         with:
           start: |
             yarn start:test-server

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,9 +16,9 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: "24"
           cache: "yarn"

--- a/.github/workflows/prettier.yml
+++ b/.github/workflows/prettier.yml
@@ -6,6 +6,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
       - name: Run Prettier
         run: npm install -g prettier@~3.0.3 && npx prettier --check .

--- a/.github/workflows/worker-tests.yml
+++ b/.github/workflows/worker-tests.yml
@@ -14,9 +14,9 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: "24"
           cache: "yarn"


### PR DESCRIPTION
## Summary

- Bumps three GitHub Actions that were flagged as targeting the deprecated Node.js 20 runtime, so they run natively on Node.js 24 instead of being silently forced:
  - `actions/checkout` v3 → v5 (cypress, deploy, prettier, worker-tests)
  - `actions/setup-node` v4 → v5 (cypress, deploy, worker-tests)
  - `cypress-io/github-action` v2 → v6 (cypress)
- `e2e Tests` already triggers on `pull_request` to `dev` (see `.github/workflows/cypress.yml` lines 7–10) — no change needed for that ask. This PR being checked by the `e2e Tests` run is the proof.

## Test plan

- [ ] `e2e Tests` job goes green on this PR
- [ ] `Worker Tests` job goes green on this PR
- [ ] `Run Prettier` job goes green on this PR
- [ ] After merge: `Deploy CDN` runs and succeeds (no PR-time check available for it)
- [ ] GitHub no longer surfaces the "Node.js 20 is deprecated" annotation on these workflow runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)