### PR TITLE
feat: customStyles option and default close chevron to white

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,34 @@ If your brand color is dark, set `toggleIconColor` to `#ffffff` so the icon rema
 
 > **Accessibility note:** Ensure your chosen `toggleColor` provides sufficient contrast with `toggleIconColor` (default `#000000`). WCAG AA requires a contrast ratio of at least 3:1 for graphical elements.
 
+### Custom Container Styles
+
+For fine-grained control over the widget's positioning or sizing, pass a `customStyles` map. Each entry is applied as an inline style on the widget's root element, so any valid CSS property (including CSS custom variables) is supported. This is useful when you need to nudge the widget away from another fixed element (e.g. a chat bubble) or override the default offsets.
+
+```html
+<script>
+  initializeAstral({
+    position: "bottom-right",
+    customStyles: {
+      bottom: "140px",
+      right: "20px",
+    },
+  });
+</script>
+```
+
+CSS custom variables exposed by the widget can be overridden the same way:
+
+```html
+<script>
+  initializeAstral({
+    customStyles: {
+      "--modalWidth": "500px",
+    },
+  });
+</script>
+```
+
 ## Language Support
 
 Astral supports multiple languages for the widget UI labels and text-to-speech voice selection. The built-in languages are:

--- a/projects/astral-accessibility/src/lib/astral-accessibility.component.scss
+++ b/projects/astral-accessibility/src/lib/astral-accessibility.component.scss
@@ -116,6 +116,10 @@
 .astral-close-icon {
   svg {
     background: var(--modalBackgroundColor);
+
+    path {
+      fill: #ffffff;
+    }
   }
 }
 

--- a/projects/astral-accessibility/src/lib/astral-accessibility.component.spec.ts
+++ b/projects/astral-accessibility/src/lib/astral-accessibility.component.spec.ts
@@ -184,6 +184,64 @@ describe("AstralAccessibilityComponent", () => {
     });
   });
 
+  describe("customStyles from astral-features attribute", () => {
+    function createWithOptions(options: Record<string, unknown>) {
+      const merged = { enabledFeatures: [], ...options };
+      const original = document.querySelector.bind(document);
+      spyOn(document, "querySelector").and.callFake((selector: string) => {
+        if (selector === "astral-accessibility") {
+          return {
+            getAttribute: (_attr: string) => JSON.stringify(merged),
+          } as unknown as Element;
+        }
+        return original(selector);
+      });
+
+      const fixture = TestBed.createComponent(AstralAccessibilityComponent);
+      fixture.detectChanges();
+      return fixture;
+    }
+
+    beforeEach(async () => {
+      await configure();
+    });
+
+    it("applies each customStyles entry as an inline style on the host", () => {
+      const fixture = createWithOptions({
+        customStyles: { bottom: "140px", right: "20px" },
+      });
+      expect(fixture.nativeElement.style.getPropertyValue("bottom")).toBe(
+        "140px",
+      );
+      expect(fixture.nativeElement.style.getPropertyValue("right")).toBe(
+        "20px",
+      );
+    });
+
+    it("supports setting CSS custom properties via customStyles", () => {
+      const fixture = createWithOptions({
+        customStyles: { "--modalWidth": "500px" },
+      });
+      expect(fixture.nativeElement.style.getPropertyValue("--modalWidth")).toBe(
+        "500px",
+      );
+    });
+
+    it("ignores non-string values in customStyles", () => {
+      const fixture = createWithOptions({
+        customStyles: { bottom: 140 as unknown as string, right: "20px" },
+      });
+      expect(fixture.nativeElement.style.getPropertyValue("bottom")).toBe("");
+      expect(fixture.nativeElement.style.getPropertyValue("right")).toBe(
+        "20px",
+      );
+    });
+
+    it("does not throw when customStyles is omitted", () => {
+      expect(() => createWithOptions({})).not.toThrow();
+    });
+  });
+
   describe("template alignment class", () => {
     let component: AstralAccessibilityComponent;
     let fixture: ComponentFixture<AstralAccessibilityComponent>;

--- a/projects/astral-accessibility/src/lib/astral-accessibility.component.ts
+++ b/projects/astral-accessibility/src/lib/astral-accessibility.component.ts
@@ -84,6 +84,15 @@ export class AstralAccessibilityComponent {
           this.options["toggleIconColor"],
         );
       }
+
+      const customStyles = this.options["customStyles"];
+      if (customStyles && typeof customStyles === "object") {
+        for (const [property, value] of Object.entries(customStyles)) {
+          if (typeof value === "string") {
+            this.elementRef.nativeElement.style.setProperty(property, value);
+          }
+        }
+      }
     }
 
     const phones =


### PR DESCRIPTION
## Summary
- Adds a `customStyles` option in the `astral-features` config — a generic `{ [cssProperty]: value }` dict applied as inline styles on the widget host. Lets consumers nudge the panel (e.g. `bottom: "140px"`), override CSS variables, or set any other valid CSS property without us shipping a new option per property.
- Flips the default fill on the close (`>`/chevron) icon to white so it's visible against the dark modal background out of the box. The accessibility-person icon on the yellow toggle background is unchanged.

## Usage
```html
<script>
  initializeAstral({
    position: "bottom-right",
    customStyles: {
      bottom: "140px",
      right: "20px",
      "--modalWidth": "500px",
    },
  });
</script>
```

## Test plan
- [ ] Unit tests pass (`yarn test`) — note: pre-existing TS errors in `text-spacing.component.ts` from the Angular upgrade are unrelated and block the suite on `dev` already.
- [ ] Manually load the demo (`yarn start:demo`) with `customStyles: { bottom: "140px" }` and confirm the toggle sits higher than the default bottom-right.
- [ ] Open the panel and confirm the close `>` icon renders white on the dark background.
- [ ] Confirm the accessibility-person icon when closed still renders black on the yellow toggle (unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)