### PR TITLE
feat: compact mode + demo customizations tab

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,19 @@ If your brand color is dark, set `toggleIconColor` to `#ffffff` so the icon rema
 
 > **Accessibility note:** Ensure your chosen `toggleColor` provides sufficient contrast with `toggleIconColor` (default `#000000`). WCAG AA requires a contrast ratio of at least 3:1 for graphical elements.
 
+### Compact Mode
+
+For pages where the widget needs to take less screen space, pass `compact: true` to `initializeAstral`. Compact mode reduces the icon size, button font size, button padding, button margin, and modal container padding inside the open panel. The toggle button itself is unchanged.
+
+```html
+<script>
+  initializeAstral({
+    compact: true,
+    enabledFeatures: ["Contrast", "Bigger Text", "Screen Mask"],
+  });
+</script>
+```
+
 ### Custom Container Styles
 
 For fine-grained control over the widget's positioning or sizing, pass a `customStyles` map. Each entry is applied as an inline style on the widget's root element, so any valid CSS property (including CSS custom variables) is supported. This is useful when you need to nudge the widget away from another fixed element (e.g. a chat bubble) or override the default offsets.

--- a/projects/astral-accessibility/src/lib/astral-accessibility.component.scss
+++ b/projects/astral-accessibility/src/lib/astral-accessibility.component.scss
@@ -52,6 +52,10 @@
 
 :host(.astral-position-bottom-left),
 :host(.astral-position-top-left) {
+  .astral-accessibility {
+    flex-direction: row-reverse;
+  }
+
   .astral-icon {
     border-radius: 0 20px 20px 0;
     padding-right: 8px;
@@ -65,6 +69,10 @@
     margin-left: -8px;
     padding-right: 10px;
     padding-left: 18px;
+  }
+
+  .astral-close-icon svg {
+    transform: scaleX(-1);
   }
 }
 

--- a/projects/astral-accessibility/src/lib/astral-accessibility.component.scss
+++ b/projects/astral-accessibility/src/lib/astral-accessibility.component.scss
@@ -155,6 +155,38 @@
   display: none;
 }
 
+:host(.astral-compact) {
+  .astral-modal {
+    padding: 8px 18px 8px 8px;
+  }
+
+  .action {
+    ::ng-deep {
+      button {
+        padding: 8px;
+        margin: 4px 0px;
+        font-size: 18px;
+      }
+
+      .icon {
+        font-size: 24px;
+
+        svg {
+          width: 24px;
+          height: 24px;
+        }
+      }
+    }
+  }
+}
+
+:host(.astral-position-bottom-left.astral-compact),
+:host(.astral-position-top-left.astral-compact) {
+  .astral-modal {
+    padding: 8px 8px 8px 18px;
+  }
+}
+
 .astral-page {
   max-width: 80vw;
 

--- a/projects/astral-accessibility/src/lib/astral-accessibility.component.ts
+++ b/projects/astral-accessibility/src/lib/astral-accessibility.component.ts
@@ -50,11 +50,16 @@ export class AstralAccessibilityComponent {
   options: Record<string, any> = {};
   enabledFeatures: String[] = [];
   position = signal<AstralPosition>("bottom-right");
+  compact = signal(false);
   isTopPosition = computed(() => this.position().startsWith("top"));
 
   @HostBinding("class")
   get hostClass(): string {
-    return `astral-position-${this.position()}`;
+    const classes = [`astral-position-${this.position()}`];
+    if (this.compact()) {
+      classes.push("astral-compact");
+    }
+    return classes.join(" ");
   }
 
   ngOnInit() {
@@ -67,6 +72,7 @@ export class AstralAccessibilityComponent {
       this.position.set(
         (this.options["position"] as AstralPosition) || "bottom-right",
       );
+      this.compact.set(Boolean(this.options["compact"]));
       if (this.options["language"]) {
         this.translationService.setLanguage(this.options["language"]);
       }

--- a/projects/astral-accessibility/src/main.ts
+++ b/projects/astral-accessibility/src/main.ts
@@ -5,6 +5,10 @@ import { AstralAccessibilityComponent } from "./lib/astral-accessibility.compone
 import { AstralTranslationService } from "./lib/astral-translation.service";
 import "zone.js";
 
+const ASTRAL_TAG = "astral-accessibility";
+
+let astralAppPromise: Promise<{ doc: Document }> | null = null;
+
 (window as any).initializeAstral = async function initializeAstral(
   features?: Record<string, any>,
 ) {
@@ -24,26 +28,34 @@ import "zone.js";
       };
     }
 
-    const app = await createApplication();
-    const widget = createCustomElement(AstralAccessibilityComponent, {
-      injector: app.injector,
-    });
-    customElements.define("astral-accessibility", widget);
+    if (!astralAppPromise) {
+      astralAppPromise = (async () => {
+        const app = await createApplication();
+        const widget = createCustomElement(AstralAccessibilityComponent, {
+          injector: app.injector,
+        });
+        if (!customElements.get(ASTRAL_TAG)) {
+          customElements.define(ASTRAL_TAG, widget);
+        }
+        const doc = app.injector.get(DOCUMENT);
+        const translationService = app.injector.get(AstralTranslationService);
+        (window as any).astralSetLanguage = (lang: string) => {
+          translationService.setLanguage(lang);
+        };
+        return { doc };
+      })();
+    }
 
-    const doc = app.injector.get(DOCUMENT);
-    const astralAccessibilityElement = doc.createElement(
-      "astral-accessibility",
-    );
+    const { doc } = await astralAppPromise;
+
+    doc.querySelectorAll(ASTRAL_TAG).forEach((el) => el.remove());
+
+    const astralAccessibilityElement = doc.createElement(ASTRAL_TAG);
     astralAccessibilityElement.setAttribute(
       "astral-features",
       JSON.stringify(features),
     );
     doc.body.appendChild(astralAccessibilityElement);
-
-    const translationService = app.injector.get(AstralTranslationService);
-    (window as any).astralSetLanguage = (lang: string) => {
-      translationService.setLanguage(lang);
-    };
   } catch (err) {
     console.error(err);
   }

--- a/projects/demo/demo-translations.js
+++ b/projects/demo/demo-translations.js
@@ -175,6 +175,12 @@ export const DEMO_TRANSLATIONS = {
       removeRow: "Remove",
       saveButton: "Save and refresh widget",
       savedAt: "Last applied at",
+      h3Snippet: "Sample code",
+      snippetHelp:
+        "Drop this into your own page to initialise the widget with the settings above.",
+      copy: "Copy",
+      copied: "Copied",
+      copyFailed: "Copy failed",
     },
   },
 
@@ -358,6 +364,12 @@ export const DEMO_TRANSLATIONS = {
       removeRow: "Supprimer",
       saveButton: "Enregistrer et actualiser le widget",
       savedAt: "Dernière application",
+      h3Snippet: "Code d'exemple",
+      snippetHelp:
+        "Copiez ceci dans votre propre page pour initialiser le widget avec les paramètres ci-dessus.",
+      copy: "Copier",
+      copied: "Copié",
+      copyFailed: "Échec de la copie",
     },
   },
 
@@ -533,6 +545,11 @@ export const DEMO_TRANSLATIONS = {
       removeRow: "移除",
       saveButton: "儲存並重新整理小工具",
       savedAt: "上次套用時間",
+      h3Snippet: "程式碼範例",
+      snippetHelp: "將此程式碼複製到您自己的頁面，即可以上述設定初始化小工具。",
+      copy: "複製",
+      copied: "已複製",
+      copyFailed: "複製失敗",
     },
   },
 };

--- a/projects/demo/demo-translations.js
+++ b/projects/demo/demo-translations.js
@@ -9,6 +9,7 @@ export const DEMO_TRANSLATIONS = {
       textSpacing: "Text Spacing",
       screenMask: "Screen Mask",
       lineHeight: "Line Height",
+      customizations: "Customizations",
     },
     home: {
       h2: "Welcome",
@@ -148,6 +149,33 @@ export const DEMO_TRANSLATIONS = {
       normalP:
         "This paragraph uses the default line height set by the stylesheet. Use it as a reference to compare how the tight paragraph above changes relative to unmodified content when you adjust the line height setting.",
     },
+    customizations: {
+      h2: "Customizations",
+      subtitle:
+        "Modify how the Astral widget is initialised on this page. Click Save to destroy the current widget and re-initialise it with your new settings.",
+      h3General: "General",
+      compactLabel: "Compact mode",
+      compactHelp:
+        "Reduce icons, font size, and padding for a smaller widget footprint.",
+      h3Features: "Enabled features",
+      h3Position: "Position",
+      positionBottomRight: "Bottom right",
+      positionBottomLeft: "Bottom left",
+      positionTopRight: "Top right",
+      positionTopLeft: "Top left",
+      h3Colors: "Toggle button colors",
+      toggleColorLabel: "Toggle background",
+      toggleIconColorLabel: "Toggle icon",
+      h3CustomStyles: "Custom styles",
+      customStylesHelp:
+        "Inline CSS overrides applied to the widget root. Any valid CSS property or custom variable is accepted (e.g. bottom: 140px, --modalWidth: 500px).",
+      propertyPlaceholder: "property",
+      valuePlaceholder: "value",
+      addRow: "Add row",
+      removeRow: "Remove",
+      saveButton: "Save and refresh widget",
+      savedAt: "Last applied at",
+    },
   },
 
   fr: {
@@ -160,6 +188,7 @@ export const DEMO_TRANSLATIONS = {
       textSpacing: "Espacement du texte",
       screenMask: "Masque d'écran",
       lineHeight: "Hauteur de ligne",
+      customizations: "Personnalisation",
     },
     home: {
       h2: "Bienvenue",
@@ -303,6 +332,33 @@ export const DEMO_TRANSLATIONS = {
       normalP:
         "Ce paragraphe utilise la hauteur de ligne par défaut définie par la feuille de style. Utilisez-le comme référence pour comparer comment le paragraphe serré ci-dessus change par rapport au contenu non modifié lorsque vous ajustez le paramètre de hauteur de ligne.",
     },
+    customizations: {
+      h2: "Personnalisation",
+      subtitle:
+        "Modifiez la façon dont le widget Astral est initialisé sur cette page. Cliquez sur Enregistrer pour détruire le widget actuel et le réinitialiser avec vos nouveaux paramètres.",
+      h3General: "Général",
+      compactLabel: "Mode compact",
+      compactHelp:
+        "Réduit les icônes, la taille de police et l'espacement pour un widget plus compact.",
+      h3Features: "Fonctionnalités activées",
+      h3Position: "Position",
+      positionBottomRight: "Bas droite",
+      positionBottomLeft: "Bas gauche",
+      positionTopRight: "Haut droite",
+      positionTopLeft: "Haut gauche",
+      h3Colors: "Couleurs du bouton",
+      toggleColorLabel: "Arrière-plan",
+      toggleIconColorLabel: "Icône",
+      h3CustomStyles: "Styles personnalisés",
+      customStylesHelp:
+        "Remplacements CSS en ligne appliqués à la racine du widget. Toute propriété CSS valide ou variable personnalisée est acceptée (par ex. bottom: 140px, --modalWidth: 500px).",
+      propertyPlaceholder: "propriété",
+      valuePlaceholder: "valeur",
+      addRow: "Ajouter une ligne",
+      removeRow: "Supprimer",
+      saveButton: "Enregistrer et actualiser le widget",
+      savedAt: "Dernière application",
+    },
   },
 
   "zh-Hant": {
@@ -315,6 +371,7 @@ export const DEMO_TRANSLATIONS = {
       textSpacing: "文字間距",
       screenMask: "螢幕遮罩",
       lineHeight: "行高",
+      customizations: "自訂",
     },
     home: {
       h2: "歡迎",
@@ -450,6 +507,32 @@ export const DEMO_TRANSLATIONS = {
       h3NormalPara: "正常段落",
       normalP:
         "此段落使用樣式表設定的預設行高。將其作為參考，比較當您調整行高設定時，上方緊湊段落相對於未修改內容的變化。",
+    },
+    customizations: {
+      h2: "自訂",
+      subtitle:
+        "修改此頁面上 Astral 小工具的初始化方式。點擊「儲存」以銷毀目前的小工具並使用新設定重新初始化。",
+      h3General: "一般",
+      compactLabel: "緊湊模式",
+      compactHelp: "縮小圖示、字體大小和間距，讓小工具佔用更少空間。",
+      h3Features: "已啟用的功能",
+      h3Position: "位置",
+      positionBottomRight: "右下",
+      positionBottomLeft: "左下",
+      positionTopRight: "右上",
+      positionTopLeft: "左上",
+      h3Colors: "切換按鈕顏色",
+      toggleColorLabel: "背景",
+      toggleIconColorLabel: "圖示",
+      h3CustomStyles: "自訂樣式",
+      customStylesHelp:
+        "套用至小工具根元素的行內 CSS 覆寫。接受任何有效的 CSS 屬性或自訂變數（例如 bottom: 140px、--modalWidth: 500px）。",
+      propertyPlaceholder: "屬性",
+      valuePlaceholder: "值",
+      addRow: "新增一列",
+      removeRow: "移除",
+      saveButton: "儲存並重新整理小工具",
+      savedAt: "上次套用時間",
     },
   },
 };

--- a/projects/demo/index.html
+++ b/projects/demo/index.html
@@ -78,6 +78,7 @@
               <${Link} href="#/text-spacing">${t.nav.textSpacing}<//>
               <${Link} href="#/screen-mask">${t.nav.screenMask}<//>
               <${Link} href="#/line-height">${t.nav.lineHeight}<//>
+              <${Link} href="#/customizations">${t.nav.customizations}<//>
             </div>
             <select
               class="lang-select"
@@ -264,8 +265,277 @@
         `;
       }
 
+      // --- Customizations ---
+      const ALL_FEATURES = [
+        "Screen Reader",
+        "Contrast",
+        "Saturation",
+        "Bigger Text",
+        "Text Spacing",
+        "Screen Mask",
+        "Line Height",
+      ];
+
+      const FEATURE_LABEL_KEYS = {
+        "Screen Reader": "screenReader",
+        Contrast: "contrast",
+        Saturation: "saturation",
+        "Bigger Text": "biggerText",
+        "Text Spacing": "textSpacing",
+        "Screen Mask": "screenMask",
+        "Line Height": "lineHeight",
+      };
+
+      const POSITIONS = [
+        "bottom-right",
+        "bottom-left",
+        "top-right",
+        "top-left",
+      ];
+
+      function defaultCustomization() {
+        const enabledFeatures = {};
+        ALL_FEATURES.forEach((f) => (enabledFeatures[f] = true));
+        return {
+          compact: false,
+          enabledFeatures,
+          position: "bottom-right",
+          toggleColor: "",
+          toggleIconColor: "",
+          customStyles: [],
+        };
+      }
+
+      function buildAstralOptions(custom, language) {
+        const options = {
+          enabledFeatures: ALL_FEATURES.filter(
+            (f) => custom.enabledFeatures[f],
+          ),
+          position: custom.position,
+        };
+        if (custom.compact) options.compact = true;
+        if (custom.toggleColor) options.toggleColor = custom.toggleColor;
+        if (custom.toggleIconColor)
+          options.toggleIconColor = custom.toggleIconColor;
+        const styles = custom.customStyles
+          .map((r) => [r.property.trim(), r.value.trim()])
+          .filter(([k, v]) => k && v);
+        if (styles.length) {
+          options.customStyles = Object.fromEntries(styles);
+        }
+        if (language && language !== "en") options.language = language;
+        return options;
+      }
+
+      function CustomizationsPage({
+        t,
+        language,
+        customization,
+        setCustomization,
+        onSave,
+        lastSavedAt,
+      }) {
+        const p = t.customizations;
+
+        function toggleCompact(e) {
+          setCustomization({ ...customization, compact: e.target.checked });
+        }
+
+        function toggleFeature(name, checked) {
+          setCustomization({
+            ...customization,
+            enabledFeatures: {
+              ...customization.enabledFeatures,
+              [name]: checked,
+            },
+          });
+        }
+
+        function setPosition(pos) {
+          setCustomization({ ...customization, position: pos });
+        }
+
+        function setColorField(field, value) {
+          setCustomization({ ...customization, [field]: value });
+        }
+
+        function updateStyleRow(index, field, value) {
+          const rows = customization.customStyles.map((r, i) =>
+            i === index ? { ...r, [field]: value } : r,
+          );
+          setCustomization({ ...customization, customStyles: rows });
+        }
+
+        function addStyleRow() {
+          setCustomization({
+            ...customization,
+            customStyles: [
+              ...customization.customStyles,
+              { property: "", value: "" },
+            ],
+          });
+        }
+
+        function removeStyleRow(index) {
+          setCustomization({
+            ...customization,
+            customStyles: customization.customStyles.filter(
+              (_, i) => i !== index,
+            ),
+          });
+        }
+
+        return html`
+          <div class="page customizations">
+            <h2>${p.h2}</h2>
+            <p class="subtitle">${p.subtitle}</p>
+
+            <h3>${p.h3General}</h3>
+            <label class="cust-row">
+              <input
+                type="checkbox"
+                checked=${customization.compact}
+                onChange=${toggleCompact}
+              />
+              <span>
+                <strong>${p.compactLabel}</strong>
+                <span class="cust-help">${p.compactHelp}</span>
+              </span>
+            </label>
+
+            <h3>${p.h3Features}</h3>
+            <div class="cust-grid">
+              ${ALL_FEATURES.map(
+                (f) => html`
+                  <label class="cust-row" key=${f}>
+                    <input
+                      type="checkbox"
+                      checked=${customization.enabledFeatures[f]}
+                      onChange=${(e) => toggleFeature(f, e.target.checked)}
+                    />
+                    <span>${t.nav[FEATURE_LABEL_KEYS[f]]}</span>
+                  </label>
+                `,
+              )}
+            </div>
+
+            <h3>${p.h3Position}</h3>
+            <div class="cust-grid">
+              ${POSITIONS.map(
+                (pos) => html`
+                  <label class="cust-row" key=${pos}>
+                    <input
+                      type="radio"
+                      name="cust-position"
+                      checked=${customization.position === pos}
+                      onChange=${() => setPosition(pos)}
+                    />
+                    <span>
+                      ${p[
+                        "position" +
+                          pos
+                            .split("-")
+                            .map((s) => s.charAt(0).toUpperCase() + s.slice(1))
+                            .join("")
+                      ]}
+                    </span>
+                  </label>
+                `,
+              )}
+            </div>
+
+            <h3>${p.h3Colors}</h3>
+            <div class="cust-color-row">
+              <label>
+                <span>${p.toggleColorLabel}</span>
+                <span class="cust-color-input">
+                  <input
+                    type="color"
+                    value=${customization.toggleColor || "#ffcb00"}
+                    onInput=${(e) =>
+                      setColorField("toggleColor", e.target.value)}
+                  />
+                  <input
+                    type="text"
+                    placeholder="#ffcb00"
+                    value=${customization.toggleColor}
+                    onInput=${(e) =>
+                      setColorField("toggleColor", e.target.value)}
+                  />
+                </span>
+              </label>
+              <label>
+                <span>${p.toggleIconColorLabel}</span>
+                <span class="cust-color-input">
+                  <input
+                    type="color"
+                    value=${customization.toggleIconColor || "#000000"}
+                    onInput=${(e) =>
+                      setColorField("toggleIconColor", e.target.value)}
+                  />
+                  <input
+                    type="text"
+                    placeholder="#000000"
+                    value=${customization.toggleIconColor}
+                    onInput=${(e) =>
+                      setColorField("toggleIconColor", e.target.value)}
+                  />
+                </span>
+              </label>
+            </div>
+
+            <h3>${p.h3CustomStyles}</h3>
+            <p class="cust-help">${p.customStylesHelp}</p>
+            ${customization.customStyles.map(
+              (row, i) => html`
+                <div class="cust-style-row" key=${i}>
+                  <input
+                    type="text"
+                    placeholder=${p.propertyPlaceholder}
+                    value=${row.property}
+                    onInput=${(e) =>
+                      updateStyleRow(i, "property", e.target.value)}
+                  />
+                  <input
+                    type="text"
+                    placeholder=${p.valuePlaceholder}
+                    value=${row.value}
+                    onInput=${(e) => updateStyleRow(i, "value", e.target.value)}
+                  />
+                  <button type="button" onClick=${() => removeStyleRow(i)}>
+                    ${p.removeRow}
+                  </button>
+                </div>
+              `,
+            )}
+            <button type="button" class="cust-add" onClick=${addStyleRow}>
+              + ${p.addRow}
+            </button>
+
+            <div class="cust-actions">
+              <button type="button" class="cust-save" onClick=${onSave}>
+                ${p.saveButton}
+              </button>
+              ${lastSavedAt
+                ? html`<span class="cust-saved-at"
+                    >${p.savedAt}: ${lastSavedAt}</span
+                  >`
+                : null}
+            </div>
+          </div>
+        `;
+      }
+
       // --- Router ---
-      function Router({ route, t }) {
+      function Router({
+        route,
+        t,
+        language,
+        customization,
+        setCustomization,
+        onSaveCustomization,
+        lastSavedAt,
+      }) {
         switch (route) {
           case "screen-reader":
             return html`<${ScreenReaderPage} t=${t} />`;
@@ -281,6 +551,15 @@
             return html`<${ScreenMaskPage} t=${t} />`;
           case "line-height":
             return html`<${LineHeightPage} t=${t} />`;
+          case "customizations":
+            return html`<${CustomizationsPage}
+              t=${t}
+              language=${language}
+              customization=${customization}
+              setCustomization=${setCustomization}
+              onSave=${onSaveCustomization}
+              lastSavedAt=${lastSavedAt}
+            />`;
           default:
             return html`<${HomePage} t=${t} />`;
         }
@@ -290,6 +569,10 @@
       function App() {
         const [language, setLanguage] = useState("en");
         const [route, setRoute] = useState(getRoute());
+        const [customization, setCustomization] = useState(
+          defaultCustomization(),
+        );
+        const [lastSavedAt, setLastSavedAt] = useState("");
 
         useEffect(() => {
           const onHash = () => setRoute(getRoute());
@@ -305,6 +588,14 @@
           if (window.astralSetLanguage) window.astralSetLanguage(lang);
         }
 
+        async function handleSaveCustomization() {
+          const options = buildAstralOptions(customization, language);
+          if (typeof window.initializeAstral === "function") {
+            await window.initializeAstral(options);
+          }
+          setLastSavedAt(new Date().toLocaleTimeString());
+        }
+
         return html`
           <${Nav}
             t=${t}
@@ -312,7 +603,15 @@
             onLanguageChange=${handleLanguageChange}
           />
           <div class="introduction">
-            <${Router} route=${route} t=${t} />
+            <${Router}
+              route=${route}
+              t=${t}
+              language=${language}
+              customization=${customization}
+              setCustomization=${setCustomization}
+              onSaveCustomization=${handleSaveCustomization}
+              lastSavedAt=${lastSavedAt}
+            />
           </div>
         `;
       }

--- a/projects/demo/index.html
+++ b/projects/demo/index.html
@@ -327,6 +327,62 @@
         return options;
       }
 
+      // JS-object-literal serializer (unquoted keys when safe, single-quoted strings).
+      function serializeOptions(value, indent = "  ") {
+        const jsKey = /^[A-Za-z_$][A-Za-z0-9_$]*$/;
+        function esc(str) {
+          return str.replace(/\\/g, "\\\\").replace(/'/g, "\\'");
+        }
+        function walk(v, depth) {
+          const pad = indent.repeat(depth);
+          const inner = indent.repeat(depth + 1);
+          if (v === null) return "null";
+          if (typeof v === "string") return `'${esc(v)}'`;
+          if (typeof v === "number" || typeof v === "boolean") return String(v);
+          if (Array.isArray(v)) {
+            if (!v.length) return "[]";
+            return (
+              "[\n" +
+              v.map((x) => inner + walk(x, depth + 1)).join(",\n") +
+              "\n" +
+              pad +
+              "]"
+            );
+          }
+          if (typeof v === "object") {
+            const keys = Object.keys(v);
+            if (!keys.length) return "{}";
+            return (
+              "{\n" +
+              keys
+                .map((k) => {
+                  const key = jsKey.test(k) ? k : `'${esc(k)}'`;
+                  return inner + key + ": " + walk(v[k], depth + 1);
+                })
+                .join(",\n") +
+              "\n" +
+              pad +
+              "}"
+            );
+          }
+          return String(v);
+        }
+        return walk(value, 0);
+      }
+
+      function buildSnippet(options) {
+        const close = "<\/script>";
+        return (
+          '<script src="astral-accessibility.js">' +
+          close +
+          "\n<script>\n" +
+          "  initializeAstral(" +
+          serializeOptions(options).replace(/\n/g, "\n  ") +
+          ");\n" +
+          close
+        );
+      }
+
       function CustomizationsPage({
         t,
         language,
@@ -336,6 +392,20 @@
         lastSavedAt,
       }) {
         const p = t.customizations;
+        const [copyStatus, setCopyStatus] = useState("");
+        const snippet = buildSnippet(
+          buildAstralOptions(customization, language),
+        );
+
+        async function copySnippet() {
+          try {
+            await navigator.clipboard.writeText(snippet);
+            setCopyStatus(p.copied);
+          } catch {
+            setCopyStatus(p.copyFailed);
+          }
+          setTimeout(() => setCopyStatus(""), 2000);
+        }
 
         function toggleCompact(e) {
           setCustomization({ ...customization, compact: e.target.checked });
@@ -521,6 +591,19 @@
                     >${p.savedAt}: ${lastSavedAt}</span
                   >`
                 : null}
+            </div>
+
+            <h3>${p.h3Snippet}</h3>
+            <p class="cust-help">${p.snippetHelp}</p>
+            <div class="cust-snippet">
+              <button
+                type="button"
+                class="cust-snippet-copy"
+                onClick=${copySnippet}
+              >
+                ${copyStatus || p.copy}
+              </button>
+              <pre><code>${snippet}</code></pre>
             </div>
           </div>
         `;

--- a/projects/demo/styles.css
+++ b/projects/demo/styles.css
@@ -315,3 +315,112 @@ nav a.active {
     font-size: 0.7rem;
   }
 }
+
+/* Customizations page */
+.page.customizations .cust-row {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.6rem;
+  margin: 0.4rem 0;
+  cursor: pointer;
+}
+
+.page.customizations .cust-row input[type="checkbox"],
+.page.customizations .cust-row input[type="radio"] {
+  margin-top: 0.3rem;
+}
+
+.page.customizations .cust-help {
+  display: block;
+  color: #666;
+  font-size: 0.9rem;
+  margin-top: 0.1rem;
+}
+
+.page.customizations .cust-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+  gap: 0 1rem;
+}
+
+.page.customizations .cust-color-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1.5rem;
+}
+
+.page.customizations .cust-color-row label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.page.customizations .cust-color-input {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+}
+
+.page.customizations .cust-color-input input[type="color"] {
+  width: 40px;
+  height: 32px;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  cursor: pointer;
+  padding: 0;
+  background: transparent;
+}
+
+.page.customizations .cust-color-input input[type="text"],
+.page.customizations .cust-style-row input[type="text"] {
+  padding: 0.4rem 0.6rem;
+  font-family: "Poppins", sans-serif;
+  font-size: 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  min-width: 0;
+}
+
+.page.customizations .cust-style-row {
+  display: grid;
+  grid-template-columns: 1fr 1fr auto;
+  gap: 0.5rem;
+  margin: 0.4rem 0;
+}
+
+.page.customizations .cust-style-row button {
+  margin: 0;
+  padding: 0.3rem 0.7rem;
+  font-size: 0.85rem;
+}
+
+.page.customizations .cust-add {
+  margin: 0.5rem 0 1rem;
+  padding: 0.4rem 0.9rem;
+  font-size: 0.9rem;
+}
+
+.page.customizations .cust-actions {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  margin-top: 1.5rem;
+  padding-top: 1rem;
+  border-top: 1px solid #e0e0e0;
+}
+
+.page.customizations .cust-save {
+  background: #ffcb00;
+  border-color: #ffcb00;
+  font-weight: 600;
+}
+
+.page.customizations .cust-save:hover {
+  background: #ffd73b;
+  border-color: #ffd73b;
+}
+
+.page.customizations .cust-saved-at {
+  color: #555;
+  font-size: 0.9rem;
+}

--- a/projects/demo/styles.css
+++ b/projects/demo/styles.css
@@ -424,3 +424,42 @@ nav a.active {
   color: #555;
   font-size: 0.9rem;
 }
+
+.page.customizations .cust-snippet {
+  position: relative;
+  margin-top: 0.5rem;
+}
+
+.page.customizations .cust-snippet pre {
+  background: #1a1a2e;
+  color: #f5f5f5;
+  border-radius: 6px;
+  padding: 1rem 1.25rem;
+  margin: 0;
+  overflow-x: auto;
+  font-size: 0.85rem;
+  line-height: 1.5;
+}
+
+.page.customizations .cust-snippet code {
+  font-family: ui-monospace, "SFMono-Regular", Menlo, Consolas, monospace;
+  white-space: pre;
+}
+
+.page.customizations .cust-snippet-copy {
+  position: absolute;
+  top: 0.6rem;
+  right: 0.6rem;
+  margin: 0;
+  padding: 0.25rem 0.7rem;
+  font-size: 0.8rem;
+  background: rgba(255, 255, 255, 0.12);
+  color: #f5f5f5;
+  border: 1px solid rgba(255, 255, 255, 0.25);
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.page.customizations .cust-snippet-copy:hover {
+  background: rgba(255, 255, 255, 0.2);
+}


### PR DESCRIPTION
## Summary
- New `compact: true` option for `initializeAstral` that shrinks action button icons to 24px, font size to 18px, button padding to 8px, button margin to 4px, and modal container padding to `8px 18px 8px 8px`. Toggle button itself is unchanged.
- `initializeAstral` is now idempotent — calling it again removes the existing `<astral-accessibility>` element and creates a fresh one with the new options. `customElements.define` is guarded so it only runs once.
- New **Customizations** tab in the demo (`#/customizations`) where you can toggle compact mode, choose enabled features, change position, set toggle colors, and add custom CSS overrides, then click Save to re-initialise the widget in place. No persistence — settings live in memory only.
- README documents the `compact` option.

## Test plan
- [ ] `yarn start:demo`, open the demo, navigate to Customizations
- [ ] Toggle Compact mode, click Save — confirm the open panel shrinks (icons 24px, button font 18px, tighter padding/margin)
- [ ] Uncheck a few features, click Save — confirm only the selected features appear in the panel
- [ ] Change position to top-left, click Save — confirm widget moves
- [ ] Set a toggle background and icon color, click Save — confirm the toggle reflects them
- [ ] Add a custom style row `bottom` / `140px`, click Save — confirm widget offset
- [ ] Confirm language selector in the nav still works after a Save
- [ ] Run `yarn cypress open` and confirm existing e2e tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)