### PR TITLE
fix(text-size): scale <select> controls and demo form fields

### DIFF
--- a/cypress/e2e/text-size-form-fields.cy.ts
+++ b/cypress/e2e/text-size-form-fields.cy.ts
@@ -1,0 +1,59 @@
+/**
+ * Verifies that the "Bigger Text" control scales form fields and their labels
+ * on the demo's Bigger Text page: the label text, a text input, a textarea and
+ * a <select> dropdown. The <select> is the important case — it has <option>
+ * children and no direct text node, so it previously escaped scaling.
+ */
+describe("bigger text scales form fields and labels", () => {
+  // Matches the label text, input, textarea and select in the demo form.
+  const FORM_FIELDS =
+    ".demo-form .demo-field-label, .demo-form input, .demo-form textarea, .demo-form select";
+
+  const mediumTextScale = 1.2;
+  const largeTextScale = 1.5;
+  const extraLargeTextScale = 1.8;
+
+  it("scales every form field and label, then restores them", () => {
+    cy.visit(`${Cypress.env("baseUrl")}#/bigger-text`);
+    cy.waitForResource("main.js");
+
+    // Make sure the demo form (including the dropdown) has rendered.
+    cy.get(".demo-form select").should("exist");
+
+    // Capture the original font size of each field, in DOM order.
+    const initial: number[] = [];
+    cy.get(FORM_FIELDS).each(($el) => {
+      initial.push(parseFloat($el.css("font-size")));
+    });
+
+    const assertScaled = (scale: number) =>
+      cy.get(FORM_FIELDS).each(($el, i) => {
+        expect(parseFloat($el.css("font-size"))).to.be.closeTo(
+          initial[i] * scale,
+          0.6,
+        );
+      });
+
+    // Open the widget so the text-size control is interactive.
+    cy.document().find("astral-accessibility").click();
+    const textSize = cy.document().find("astral-text-size");
+
+    // Medium
+    textSize.click();
+    assertScaled(mediumTextScale);
+
+    // Large
+    textSize.click();
+    assertScaled(largeTextScale);
+
+    // Extra Large
+    textSize.click();
+    assertScaled(extraLargeTextScale);
+
+    // Revert back to the base size.
+    textSize.click();
+    cy.get(FORM_FIELDS).each(($el, i) => {
+      expect(parseFloat($el.css("font-size"))).to.be.closeTo(initial[i], 0.6);
+    });
+  });
+});

--- a/projects/astral-accessibility/src/lib/controls/text-size.component.spec.ts
+++ b/projects/astral-accessibility/src/lib/controls/text-size.component.spec.ts
@@ -39,3 +39,66 @@ describe("TextSizeComponent labels", () => {
     expect(component.labels[3]).toBe("超大文字");
   });
 });
+
+describe("TextSizeComponent form field scaling", () => {
+  let component: TextSizeComponent;
+  let container: HTMLElement;
+
+  const FIELD_IDS = ["ff-label", "ff-input", "ff-textarea", "ff-select"];
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [TextSizeComponent],
+    }).compileComponents();
+
+    const fixture = TestBed.createComponent(TextSizeComponent);
+    component = fixture.componentInstance;
+
+    container = document.createElement("div");
+    container.innerHTML = `
+      <label id="ff-label" for="ff-input">Full name</label>
+      <input id="ff-input" type="text" value="Jane Doe" />
+      <textarea id="ff-textarea">Notes</textarea>
+      <select id="ff-select">
+        <option>Option one</option>
+        <option>Option two</option>
+      </select>
+    `;
+    document.body.appendChild(container);
+  });
+
+  afterEach(() => {
+    container.remove();
+  });
+
+  function fontSizeOf(id: string): number {
+    return parseFloat(
+      window.getComputedStyle(document.getElementById(id)!).fontSize,
+    );
+  }
+
+  it("scales form fields and their labels by the selected factor", () => {
+    const scale = 1.5;
+    const initial: Record<string, number> = {};
+    FIELD_IDS.forEach((id) => (initial[id] = fontSizeOf(id)));
+
+    component.updateTextSize(container, scale, 1);
+
+    FIELD_IDS.forEach((id) => {
+      expect(fontSizeOf(id)).toBeCloseTo(initial[id] * scale, 1);
+    });
+  });
+
+  it("restores the original size of form fields and labels", () => {
+    const scale = 1.8;
+    const initial: Record<string, number> = {};
+    FIELD_IDS.forEach((id) => (initial[id] = fontSizeOf(id)));
+
+    component.updateTextSize(container, scale, 1);
+    component.restoreTextSize(container);
+
+    FIELD_IDS.forEach((id) => {
+      expect(fontSizeOf(id)).toBeCloseTo(initial[id], 1);
+    });
+  });
+});

--- a/projects/astral-accessibility/src/lib/controls/text-size.component.ts
+++ b/projects/astral-accessibility/src/lib/controls/text-size.component.ts
@@ -141,13 +141,18 @@ export class TextSizeComponent {
       }
     }
 
+    // Form controls (e.g. <select>) render their own text independently of
+    // their children, so scale them directly even though they have child nodes.
+    const formControls = ["INPUT", "SELECT", "TEXTAREA", "BUTTON"];
+
     if (
       Array.from(node.childNodes).some(
         (child) =>
           child.nodeType === child.TEXT_NODE &&
           child.nodeValue?.replace(/\s*/i, "")?.length,
       ) ||
-      children.length === 0
+      children.length === 0 ||
+      formControls.includes(node.nodeName)
     ) {
       const currentFontSize = window.getComputedStyle(node).fontSize;
       const currentFontSizeNum = parseFloat(currentFontSize);

--- a/projects/demo/demo-translations.js
+++ b/projects/demo/demo-translations.js
@@ -97,6 +97,17 @@ export const DEMO_TRANSLATIONS = {
       h3Navigate: "Navigate and return",
       navigateP:
         "Set the text size to Large, navigate to the Screen Reader page, then return here. The paragraph sizes above should be exactly 1.5× their original values — not 1.5× compounded over multiple navigations.",
+      h3FormFields: "Form fields and labels",
+      formIntro:
+        "Text scaling also applies to form controls and their labels. Enable a text size level and watch the label, text input, message box, and dropdown below grow with the rest of the page.",
+      formNameLabel: "Full name",
+      formNamePlaceholder: "Jane Doe",
+      formMessageLabel: "Message",
+      formMessagePlaceholder: "Type your message here",
+      formPriorityLabel: "Priority",
+      formPriorityLow: "Low",
+      formPriorityMedium: "Medium",
+      formPriorityHigh: "High",
     },
     textSpacing: {
       h2: "Text Spacing",
@@ -286,6 +297,17 @@ export const DEMO_TRANSLATIONS = {
       h3Navigate: "Naviguer et revenir",
       navigateP:
         "Réglez la taille du texte sur Grand, naviguez vers la page Lecteur d'écran, puis revenez ici. Les tailles de paragraphe ci-dessus devraient être exactement 1,5× leurs valeurs d'origine — pas 1,5× composé sur plusieurs navigations.",
+      h3FormFields: "Champs de formulaire et étiquettes",
+      formIntro:
+        "La mise à l'échelle du texte s'applique aussi aux champs de formulaire et à leurs étiquettes. Activez un niveau de taille de texte et observez l'étiquette, le champ de saisie, la zone de message et la liste déroulante ci-dessous s'agrandir avec le reste de la page.",
+      formNameLabel: "Nom complet",
+      formNamePlaceholder: "Jeanne Dupont",
+      formMessageLabel: "Message",
+      formMessagePlaceholder: "Saisissez votre message ici",
+      formPriorityLabel: "Priorité",
+      formPriorityLow: "Faible",
+      formPriorityMedium: "Moyenne",
+      formPriorityHigh: "Élevée",
     },
     textSpacing: {
       h2: "Espacement du texte",
@@ -469,6 +491,17 @@ export const DEMO_TRANSLATIONS = {
       h3Navigate: "導航並返回",
       navigateP:
         "將文字大小設為大，導航到螢幕閱讀器頁面，然後返回此處。上方的段落大小應恰好是其原始值的 1.5×——而不是在多次導航中複合的 1.5×。",
+      h3FormFields: "表單欄位與標籤",
+      formIntro:
+        "文字縮放同樣適用於表單控制項及其標籤。啟用文字大小等級，觀察下方的標籤、文字輸入框、訊息框和下拉選單會隨頁面其餘部分一起放大。",
+      formNameLabel: "全名",
+      formNamePlaceholder: "王小明",
+      formMessageLabel: "訊息",
+      formMessagePlaceholder: "在此輸入您的訊息",
+      formPriorityLabel: "優先順序",
+      formPriorityLow: "低",
+      formPriorityMedium: "中",
+      formPriorityHigh: "高",
     },
     textSpacing: {
       h2: "文字間距",

--- a/projects/demo/index.html
+++ b/projects/demo/index.html
@@ -208,6 +208,34 @@
             <p style="font-size: 20px">${p.sample20px}</p>
             <h3>${p.h3Navigate}</h3>
             <p>${p.navigateP}</p>
+            <h3>${p.h3FormFields}</h3>
+            <p>${p.formIntro}</p>
+            <form class="demo-form" onSubmit=${(e) => e.preventDefault()}>
+              <label class="demo-field">
+                <span class="demo-field-label">${p.formNameLabel}</span>
+                <input
+                  type="text"
+                  name="demo-name"
+                  placeholder=${p.formNamePlaceholder}
+                />
+              </label>
+              <label class="demo-field">
+                <span class="demo-field-label">${p.formMessageLabel}</span>
+                <textarea
+                  name="demo-message"
+                  rows="3"
+                  placeholder=${p.formMessagePlaceholder}
+                ></textarea>
+              </label>
+              <label class="demo-field">
+                <span class="demo-field-label">${p.formPriorityLabel}</span>
+                <select name="demo-priority">
+                  <option value="low">${p.formPriorityLow}</option>
+                  <option value="medium">${p.formPriorityMedium}</option>
+                  <option value="high">${p.formPriorityHigh}</option>
+                </select>
+              </label>
+            </form>
           </div>
         `;
       }

--- a/projects/demo/styles.css
+++ b/projects/demo/styles.css
@@ -463,3 +463,35 @@ nav a.active {
 .page.customizations .cust-snippet-copy:hover {
   background: rgba(255, 255, 255, 0.2);
 }
+
+.demo-form {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  max-width: 420px;
+  margin-top: 0.5rem;
+}
+
+.demo-form .demo-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.demo-form .demo-field-label {
+  font-weight: 600;
+}
+
+.demo-form input,
+.demo-form textarea,
+.demo-form select {
+  padding: 0.5rem 0.65rem;
+  border: 1px solid rgba(0, 0, 0, 0.25);
+  border-radius: 6px;
+  background: #fff;
+  color: #1a1a1a;
+}
+
+.demo-form textarea {
+  resize: vertical;
+}


### PR DESCRIPTION
## What & why

Form controls weren't fully covered by the **Bigger Text** feature. The scaler walks the DOM and scales an element's `font-size` only when it has direct text content **or** no child elements. A `<select>` has `<option>` children but no direct text node of its own, so its own `font-size` was never scaled — the closed dropdown's displayed text stayed at the browser default size while everything else grew. (`<input>`, `<textarea>` and `<label>` already scaled, but there was no demo or test exercising them.)

## Changes

- **Fix** (`text-size.component.ts`): include form controls (`INPUT`, `SELECT`, `TEXTAREA`, `BUTTON`) in the scaling condition so they scale directly regardless of their children.
- **Demo**: added a form (label + text input, message `textarea`, and priority `select`) to the Bigger Text page, with `fr` / `zh-Hant` translations and light styling, so the behaviour is visible in the example app.
- **Tests**:
  - Unit (`text-size.component.spec.ts`): new `TextSizeComponent form field scaling` suite — asserts label, input, textarea and **select** all scale by the selected factor and restore correctly. This test fails on `main` for `<select>` and passes with the fix.
  - E2E (`cypress/e2e/text-size-form-fields.cy.ts`): drives the demo Bigger Text page through Medium/Large/Extra Large and back, asserting every form field and label scales and restores.

## Verification

- `ng test` (headless Chrome): **86/86 passing**
- `cypress run` (all e2e specs): **14/14 passing**
- `prettier@3.0.3 --check` (CI version): clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)