### PR TITLE
fix: apply text-size font-size with `important` priority

### DIFF
--- a/projects/astral-accessibility/src/lib/controls/text-size.component.ts
+++ b/projects/astral-accessibility/src/lib/controls/text-size.component.ts
@@ -157,7 +157,15 @@ export class TextSizeComponent {
       const currentFontSize = window.getComputedStyle(node).fontSize;
       const currentFontSizeNum = parseFloat(currentFontSize);
 
-      node.style.fontSize = `${(currentFontSizeNum / previousScale) * scale}px`;
+      // Apply with `important` priority so the accessibility override wins over
+      // app stylesheet rules that use `!important` (e.g. `font-size: 18px !important`).
+      // A normal inline style loses to an author `!important` rule in the cascade,
+      // which otherwise leaves such elements (e.g. labels/captions) unscaled.
+      node.style.setProperty(
+        "font-size",
+        `${(currentFontSizeNum / previousScale) * scale}px`,
+        "important",
+      );
       node.style.lineHeight = `initial`;
       node.style.wordSpacing = `initial`;
     }


### PR DESCRIPTION
## Problem

The **Text Size** accessibility control enlarges text by writing a plain inline `element.style.fontSize` on every text-bearing element:

```ts
node.style.fontSize = `${(currentFontSizeNum / previousScale) * scale}px`;
```

A **normal inline style loses to an author stylesheet rule marked `!important`** in the CSS cascade (order: author `!important` › inline normal › author normal). So on any consuming app that pins font-size with `!important`, those elements never scale when the user increases text size — the accessibility control silently does nothing for them.

Concrete case: Engage's FHA registration wizard sets `font-size: 18px !important` on labels/captions (to override Astral's own component defaults), so labels stayed at 18px regardless of the Text Size setting.

## Fix

Apply the inline font-size with `important` priority:

```ts
node.style.setProperty(
  "font-size",
  `${(currentFontSizeNum / previousScale) * scale}px`,
  "important",
);
```

Inline `!important` beats stylesheet `!important`, so the accessibility override now wins for every consumer — this is the correct behavior for an accessibility control, which should be authoritative over app styling.

## Why this is safe

- The **restore path** (`restoreTextSize`) already uses `node.style.setProperty(key, value)` with the saved original value (typically `""`). `setProperty("font-size", "")` removes the property *including* its priority flag, so turning Text Size off / resetting to base is unaffected.
- `line-height`/`word-spacing` are left as-is (normal `initial`); only `font-size` was the source of the cascade conflict.
- On subsequent re-apply passes the computed font-size now reflects Astral's own applied value and is divided back by `previousScale` as before, so scaling math is unchanged.

_Note: the same commit was previously merged to `dev` via #145; this PR lands it on `main`._

🤖 Generated with [Claude Code](https://claude.com/claude-code)