### PR TITLE
fix: apply text-size font-size with `important` priority

### DIFF
--- a/projects/astral-accessibility/src/lib/controls/text-size.component.ts
+++ b/projects/astral-accessibility/src/lib/controls/text-size.component.ts
@@ -157,7 +157,15 @@ export class TextSizeComponent {
       const currentFontSize = window.getComputedStyle(node).fontSize;
       const currentFontSizeNum = parseFloat(currentFontSize);
 
-      node.style.fontSize = `${(currentFontSizeNum / previousScale) * scale}px`;
+      // Apply with `important` priority so the accessibility override wins over
+      // app stylesheet rules that use `!important` (e.g. `font-size: 18px !important`).
+      // A normal inline style loses to an author `!important` rule in the cascade,
+      // which otherwise leaves such elements (e.g. labels/captions) unscaled.
+      node.style.setProperty(
+        "font-size",
+        `${(currentFontSizeNum / previousScale) * scale}px`,
+        "important",
+      );
       node.style.lineHeight = `initial`;
       node.style.wordSpacing = `initial`;
     }


### PR DESCRIPTION
The Text Size accessibility control enlarged text by writing a plain inline `element.style.fontSize`, which has lower cascade precedence than an author stylesheet rule marked `!important`. On apps that pin element sizes with `!important` (e.g. Engage's registration wizard uses `font-size: 18px !important` on labels/captions), those elements never scaled when the user increased text size.

Set the inline font-size with `important` priority via `setProperty(..., "important")` so the accessibility override wins over app `!important` rules. The restore path (`setProperty(key, "")`) already clears the property including its priority flag, so disabling/resetting text size is unaffected.